### PR TITLE
Improved Entry Removal Performance

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -17,11 +17,9 @@ extension Archive {
     ///   - entry: The ZIP `Entry` to read.
     ///   - url: The destination file URL.
     ///   - bufferSize: The maximum size of the read buffer and the decompression buffer (if needed).
-    ///   - skipDecompression: Indicates that content should be written without performing decompression.
     /// - Returns: The checksum of the processed content.
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, to url: URL, bufferSize: UInt32 = defaultReadChunkSize,
-                        skipDecompression: Bool = false) throws -> CRC32 {
+    public func extract(_ entry: Entry, to url: URL, bufferSize: UInt32 = defaultReadChunkSize) throws -> CRC32 {
         let fileManager = FileManager()
         var checksum = CRC32(0)
         switch entry.type {
@@ -35,14 +33,12 @@ extension Archive {
             let destinationFile: UnsafeMutablePointer<FILE> = fopen(destinationFileSystemRepresentation, "wb+")
             defer { fclose(destinationFile) }
             let consumer = { _ = try Data.write(chunk: $0, to: destinationFile) }
-            checksum = try self.extract(entry, bufferSize: bufferSize,
-                                        skipDecompression: skipDecompression, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, consumer: consumer)
         case .directory:
             let consumer = { (_: Data) in
                 try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
             }
-            checksum = try self.extract(entry, bufferSize: bufferSize,
-                                        skipDecompression: skipDecompression, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, consumer: consumer)
         case .symlink:
             guard !fileManager.fileExists(atPath: url.path) else {
                 throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteFileExists.rawValue,
@@ -53,8 +49,7 @@ extension Archive {
                 try fileManager.createParentDirectoryStructure(for: url)
                 try fileManager.createSymbolicLink(atPath: url.path, withDestinationPath: linkPath)
             }
-            checksum = try self.extract(entry, bufferSize: bufferSize,
-                                        skipDecompression: skipDecompression, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, consumer: consumer)
         }
         let attributes = FileManager.attributes(from: entry.centralDirectoryStructure)
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
@@ -66,12 +61,10 @@ extension Archive {
     /// - Parameters:
     ///   - entry: The ZIP `Entry` to read.
     ///   - bufferSize: The maximum size of the read buffer and the decompression buffer (if needed).
-    ///   - skipDecompression: Indicates that content should be written without performing decompression.
     ///   - consumer: A closure that consumes contents of `Entry` as `Data` chunks.
     /// - Returns: The checksum of the processed content.
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize,
-                        skipDecompression: Bool = false, consumer: Consumer) throws -> CRC32 {
+    public func extract(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, consumer: Consumer) throws -> CRC32 {
         var checksum = CRC32(0)
         let localFileHeader = entry.localFileHeader
         fseek(self.archiveFile, entry.dataOffset, SEEK_SET)
@@ -80,17 +73,9 @@ extension Archive {
             guard let compressionMethod = CompressionMethod(rawValue: localFileHeader.compressionMethod) else {
                 throw ArchiveError.invalidCompressionMethod
             }
-            if skipDecompression {
-                let isCompressed = compressionMethod == .deflate
-                let centralDirStructure = entry.centralDirectoryStructure
-                let size = isCompressed ? centralDirStructure.compressedSize : centralDirStructure.uncompressedSize
-                checksum = try Data.consumePart(of: self.archiveFile, size: Int(size),
-                                                chunkSize: Int(bufferSize), consumer: consumer)
-            } else {
-                switch compressionMethod {
-                case .none: checksum = try self.readUncompressed(entry: entry, bufferSize: bufferSize, with: consumer)
-                case .deflate: checksum = try self.readCompressed(entry: entry, bufferSize: bufferSize, with: consumer)
-                }
+            switch compressionMethod {
+            case .none: checksum = try self.readUncompressed(entry: entry, bufferSize: bufferSize, with: consumer)
+            case .deflate: checksum = try self.readCompressed(entry: entry, bufferSize: bufferSize, with: consumer)
             }
         case .directory: try consumer(Data())
         case .symlink:

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -114,7 +114,6 @@ extension ZIPFoundationTests {
         }
         var itemsExist = false
         for entry in archive {
-            print(entry.type)
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
             itemsExist = fileManager.fileExists(atPath: directoryURL.path)
             if !itemsExist {


### PR DESCRIPTION
Fixes #4 
Fixes #6 

Refactored entry removal to avoid seeks and CRC32 checksumming.
Also cleaned up API a bit.