### PR TITLE
Non-existant File Error Handling for addEntry

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -65,8 +65,7 @@ extension Archive {
                 let linkFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: linkDestination)
                 let linkLength = Int(strlen(linkFileSystemRepresentation))
                 let linkBuffer = UnsafeBufferPointer(start: linkFileSystemRepresentation, count: linkLength)
-                let linkData = Data.init(buffer: linkBuffer)
-                return linkData
+                return Data.init(buffer: linkBuffer)
             }
             try self.addEntry(with: path, type: type, uncompressedSize: uncompressedSize,
                               modificationDate: modDate, permissions: permissions,

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -29,6 +29,10 @@ extension Archive {
                          bufferSize: UInt32 = defaultWriteChunkSize) throws {
         let fileManager = FileManager()
         let entryURL = baseURL.appendingPathComponent(path)
+        guard fileManager.fileExists(atPath: entryURL.path) else {
+            throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadNoSuchFile.rawValue,
+                          userInfo: [NSFilePathErrorKey: entryURL.path])
+        }
         guard fileManager.isReadableFile(atPath: entryURL.path) else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadNoPermission.rawValue,
                           userInfo: [NSFilePathErrorKey: url.path])

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -111,7 +111,7 @@ extension ZIPFoundationTests {
         do {
             try archive.addEntry(with: nonExistantRelativePath, relativeTo: nonExistantBaseURL)
         } catch let error as CocoaError {
-            XCTAssert(error.code == .fileReadNoPermission)
+            XCTAssert(error.code == .fileReadNoSuchFile)
             didCatchExpectedError = true
         } catch {
             XCTFail("Unexpected error thrown while trying to add non-existant file to an archive.")


### PR DESCRIPTION
Fixes #23 

Adds a "file exists" check at the beginning of `addEntry`