### PR TITLE
Linux Test Suite Improvements

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -317,12 +317,12 @@ extension Archive {
     private func replaceCurrentArchiveWithArchive(at URL: URL) throws {
         fclose(self.archiveFile)
         let fileManager = FileManager()
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             _ = try fileManager.replaceItemAt(self.url, withItemAt: URL)
-#else
+        #else
             _ = try fileManager.removeItem(at: self.url)
             _ = try fileManager.moveItem(at: URL, to: self.url)
-#endif
+        #endif
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: self.url.path)
         self.archiveFile = fopen(fileSystemRepresentation, "rb+")
     }

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -114,21 +114,21 @@ extension Data {
     }
 
     static func compress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         return try self.process(operation: COMPRESSION_STREAM_ENCODE, size: size, bufferSize: bufferSize,
                                 provider: provider, consumer: consumer)
-#else
+        #else
         return try self.encode(size: size, bufferSize: bufferSize, provider: provider, consumer: consumer)
-#endif
+        #endif
     }
 
     static func decompress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
                                 provider: provider, consumer: consumer)
-#else
+        #else
         return try self.decode(bufferSize: bufferSize, provider: provider, consumer: consumer)
-#endif
+        #endif
     }
 }
 

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -134,7 +134,8 @@ extension FileManager {
             return attributes
         }
         let externalFileAttributes = centralDirectoryStructure.externalFileAttributes
-        attributes[.posixPermissions] = self.permissions(for: externalFileAttributes, osType: osType)
+        let permissions = self.permissions(for: externalFileAttributes, osType: osType)
+        attributes[.posixPermissions] = NSNumber(value: permissions)
         attributes[.modificationDate] = Date(dateTime: (fileDate, fileTime))
         return attributes
     }

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -181,11 +181,11 @@ extension FileManager {
         let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
         var fileStat = stat()
         lstat(entryFileSystemRepresentation, &fileStat)
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         let modTimeSpec = fileStat.st_mtimespec
-#else
+        #else
         let modTimeSpec = fileStat.st_mtim
-#endif
+        #endif
 
         let timeStamp = TimeInterval(modTimeSpec.tv_sec) + TimeInterval(modTimeSpec.tv_nsec)/1000000000.0
         let modDate = Date(timeIntervalSince1970: timeStamp)

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -216,16 +216,6 @@ extension FileManager {
     }
 }
 
-public extension CocoaError {
-    public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable: Any]? = nil, url: URL? = nil) -> Error {
-        var info: [String: Any] = userInfo as? [String: Any] ?? [:]
-        if let url = url {
-            info[NSURLErrorKey] = url
-        }
-        return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: info)
-    }
-}
-
 extension Date {
     init(dateTime: (UInt16, UInt16)) {
         var msdosDateTime = Int(dateTime.0)

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -215,6 +215,16 @@ extension FileManager {
     }
 }
 
+public extension CocoaError {
+    public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable: Any]? = nil, url: URL? = nil) -> Error {
+        var info: [String: Any] = userInfo as? [String: Any] ?? [:]
+        if let url = url {
+            info[NSURLErrorKey] = url
+        }
+        return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: info)
+    }
+}
+
 extension Date {
     init(dateTime: (UInt16, UInt16)) {
         var msdosDateTime = Int(dateTime.0)

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -57,6 +57,7 @@ extension ZIPFoundationTests {
         XCTAssert(parentDirectoryArchive.checkIntegrity())
     }
 
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     func testZipItemProgress() {
         let fileManager = FileManager()
         let assetURL = self.resourceURL(for: #function, pathExtension: "png")
@@ -103,6 +104,7 @@ extension ZIPFoundationTests {
         }
         self.wait(for: [fileExpectation, directoryExpectation], timeout: 20.0)
     }
+    #endif
 
     func testZipItemErrorConditions() {
         let fileManager = FileManager()
@@ -162,6 +164,7 @@ extension ZIPFoundationTests {
         XCTAssert(itemsExist)
     }
 
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     func testUnzipItemProgress() {
         let fileManager = FileManager()
         let archive = self.archive(for: #function, mode: .read)
@@ -186,6 +189,7 @@ extension ZIPFoundationTests {
         }
         self.wait(for: [expectation], timeout: 10.0)
     }
+    #endif
 
     func testUnzipItemErrorConditions() {
         var nonexistantArchiveURL = ZIPFoundationTests.tempZipDirectoryURL

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -365,22 +365,22 @@ extension ZIPFoundationTests {
     }
 
     func testPOSIXPermissions() {
-        let permissions = Int16(0o753)
+        let permissions = NSNumber(value: Int16(0o753))
         let assetURL = self.resourceURL(for: #function, pathExtension: "png")
         let fileManager = FileManager()
         let archive = self.archive(for: #function, mode: .create)
         do {
-            try fileManager.setAttributes([.posixPermissions: NSNumber(value: permissions)], ofItemAtPath: assetURL.path)
+            try fileManager.setAttributes([.posixPermissions: permissions], ofItemAtPath: assetURL.path)
             let relativePath = assetURL.lastPathComponent
             let baseURL = assetURL.deletingLastPathComponent()
             try archive.addEntry(with: relativePath, relativeTo: baseURL)
             guard let entry = archive["\(assetURL.lastPathComponent)"] else {
                 throw Archive.ArchiveError.unreadableArchive
             }
-            guard let filePermissions = entry.fileAttributes[.posixPermissions] as? UInt16 else {
+            guard let filePermissions = entry.fileAttributes[.posixPermissions] as? NSNumber else {
                 throw CocoaError(CocoaError.fileReadUnknown)
             }
-            XCTAssert(permissions == filePermissions)
+            XCTAssert(permissions.int16Value == filePermissions.int16Value)
         } catch { XCTFail("Failed to test POSIX permissions") }
     }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -370,7 +370,7 @@ extension ZIPFoundationTests {
         let fileManager = FileManager()
         let archive = self.archive(for: #function, mode: .create)
         do {
-            try fileManager.setAttributes([.posixPermissions: permissions], ofItemAtPath: assetURL.path)
+            try fileManager.setAttributes([.posixPermissions: NSNumber(value: permissions)], ofItemAtPath: assetURL.path)
             let relativePath = assetURL.lastPathComponent
             let baseURL = assetURL.deletingLastPathComponent()
             try archive.addEntry(with: relativePath, relativeTo: baseURL)

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -41,10 +41,10 @@ extension ZIPFoundationTests {
         let archive = self.archive(for: #function, mode: .read)
         for entry in archive {
             do {
-                //Test extracting to memory
+                // Test extracting to memory
                 var checksum = try archive.extract(entry, bufferSize: 128, consumer: { _ in })
                 XCTAssert(entry.checksum == checksum)
-                //Test extracting to file
+                // Test extracting to file
                 var fileURL = self.createDirectory(for: #function)
                 fileURL.appendPathComponent(entry.path)
                 checksum = try archive.extract(entry, to: fileURL)

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -72,7 +72,7 @@ class ZIPFoundationTests: XCTestCase {
         var unreadableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         let processInfo = ProcessInfo.processInfo
         unreadableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let noPermissionAttributes = [FileAttributeKey.posixPermissions: Int16(0o000)]
+        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
         let fileManager = FileManager()
         var result = fileManager.createFile(atPath: unreadableArchiveURL.path, contents: nil,
                                                     attributes: noPermissionAttributes)
@@ -81,7 +81,7 @@ class ZIPFoundationTests: XCTestCase {
         XCTAssertNil(unreadableArchive)
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: defaultPermissions]
+        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultPermissions)]
         result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                                 attributes: fullPermissionAttributes)
         XCTAssert(result == true)

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -233,14 +233,14 @@ class ZIPFoundationTests: XCTestCase {
 extension ZIPFoundationTests {
     // From https://oleb.net/blog/2017/03/keeping-xctest-in-sync/
     func testLinuxTestSuiteIncludesAllTests() {
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
             let thisClass = type(of: self)
             let linuxCount = thisClass.allTests.count
             let darwinCount = Int(thisClass
                 .defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount,
                            "\(darwinCount - linuxCount) tests are missing from allTests")
-#endif
+        #endif
     }
 
     static var allTests: [(String, (ZIPFoundationTests) -> () throws -> Void)] {
@@ -256,8 +256,6 @@ extension ZIPFoundationTests {
             ("testCreateArchiveAddCompressedEntry", testCreateArchiveAddCompressedEntry),
             ("testCreateArchiveAddDirectory", testCreateArchiveAddDirectory),
             ("testCreateArchiveAddEntryErrorConditions", testCreateArchiveAddEntryErrorConditions),
-            ("testArchiveAddUncompressedEntryProgress", testArchiveAddUncompressedEntryProgress),
-            ("testArchiveAddCompressedEntryProgress", testArchiveAddCompressedEntryProgress),
             ("testCreateArchiveAddLargeCompressedEntry", testCreateArchiveAddLargeCompressedEntry),
             ("testCreateArchiveAddLargeUncompressedEntry", testCreateArchiveAddLargeUncompressedEntry),
             ("testCreateArchiveAddSymbolicLink", testCreateArchiveAddSymbolicLink),
@@ -299,17 +297,28 @@ extension ZIPFoundationTests {
             ("testRemoveCompressedEntry", testRemoveCompressedEntry),
             ("testRemoveDataDescriptorCompressedEntry", testRemoveDataDescriptorCompressedEntry),
             ("testRemoveEntryErrorConditions", testRemoveEntryErrorConditions),
-            ("testRemoveEntryProgress", testRemoveEntryProgress),
             ("testRemoveUncompressedEntry", testRemoveUncompressedEntry),
             ("testUnzipItem", testUnzipItem),
             ("testUnzipItemErrorConditions", testUnzipItemErrorConditions),
-            ("testUnzipItemProgress", testUnzipItemProgress),
             ("testWriteChunkErrorConditions", testWriteChunkErrorConditions),
             ("testZipItem", testZipItem),
             ("testZipItemErrorConditions", testZipItemErrorConditions),
-            ("testZipItemProgress", testZipItemProgress),
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+        ] + darwinOnlyTests
+    }
+
+    static var darwinOnlyTests: [(String, (ZIPFoundationTests) -> () throws -> Void)] {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        return [
+            ("testZipItemProgress", testZipItemProgress),
+            ("testUnzipItemProgress", testUnzipItemProgress),
+            ("testRemoveEntryProgress", testRemoveEntryProgress),
+            ("testArchiveAddUncompressedEntryProgress", testArchiveAddUncompressedEntryProgress),
+            ("testArchiveAddCompressedEntryProgress", testArchiveAddCompressedEntryProgress)
         ]
+        #else
+        return []
+        #endif
     }
 }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -373,7 +373,7 @@ extension ZIPFoundationTests {
         let processInfo = ProcessInfo.processInfo
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: defaultPermissions]
+        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultPermissions)]
         let fileManager = FileManager()
         let result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                                     attributes: fullPermissionAttributes)
@@ -387,7 +387,7 @@ extension ZIPFoundationTests {
         var nonUpdatableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         let processInfo = ProcessInfo.processInfo
         nonUpdatableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let noPermissionAttributes = [FileAttributeKey.posixPermissions: Int16(0o000)]
+        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
         let fileManager = FileManager()
         let result = fileManager.createFile(atPath: nonUpdatableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -117,6 +117,7 @@ extension ZIPFoundationTests {
         XCTAssertTrue(didCatchExpectedError)
     }
 
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     func testArchiveAddUncompressedEntryProgress() {
         let archive = self.archive(for: #function, mode: .update)
         let assetURL = self.resourceURL(for: #function, pathExtension: "png")
@@ -177,6 +178,7 @@ extension ZIPFoundationTests {
         XCTAssert(progress.fractionCompleted > 0.5)
         XCTAssert(archive.checkIntegrity())
     }
+    #endif
 
     func testArchiveAddEntryErrorConditions() {
         var didCatchExpectedError = false
@@ -285,6 +287,7 @@ extension ZIPFoundationTests {
         XCTAssert(archive.checkIntegrity())
     }
 
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     func testRemoveEntryProgress() {
         let archive = self.archive(for: #function, mode: .update)
         guard let entryToRemove = archive["test/data.random"] else {
@@ -315,6 +318,7 @@ extension ZIPFoundationTests {
         XCTAssert(progress.fractionCompleted > 0.5)
         XCTAssert(archive.checkIntegrity())
     }
+    #endif
 
     func testRemoveDataDescriptorCompressedEntry() {
         let archive = self.archive(for: #function, mode: .update)
@@ -340,11 +344,11 @@ extension ZIPFoundationTests {
         // We don't have access to the temp archive file that Archive.remove
         // uses. To exercise the error code path, we temporarily limit the number of open files for
         // the test process to exercise the error code path here.
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         let fileNoFlag = RLIMIT_NOFILE
-#else
+        #else
         let fileNoFlag = Int32(RLIMIT_NOFILE.rawValue)
-#endif
+        #endif
         var storedRlimit = rlimit()
         getrlimit(fileNoFlag, &storedRlimit)
         var tempRlimit = storedRlimit


### PR DESCRIPTION
# Changes proposed in this PR
* Wraps file attribute values in `NSNumber` (not needed on Darwin but necessary for Linux because of different bridging behaviour)
* Excludes tests that rely on KVO from the Linux test suite
