### PR TITLE
 Fix an issue with unpacking files within directories on macOS

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -51,7 +51,7 @@ extension Archive {
             }
             checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
         }
-        let attributes = FileManager.attributes(from: entry)
+        let attributes = FileManager.attributes(from: entry.centralDirectoryStructure, for: entry.type)
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
         return checksum
     }

--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -51,7 +51,7 @@ extension Archive {
             }
             checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
         }
-        let attributes = FileManager.attributes(from: entry.centralDirectoryStructure)
+        let attributes = FileManager.attributes(from: entry)
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
         return checksum
     }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -90,7 +90,7 @@ extension Archive {
     ///   - provider: A closure that accepts a position and a chunk size. Returns a `Data` chunk.
     /// - Throws: An error if the source data is invalid or the receiver is not writable.
     public func addEntry(with path: String, type: Entry.EntryType, uncompressedSize: UInt32,
-                         modificationDate: Date = Date(), permissions: UInt16 = defaultPermissions,
+                         modificationDate: Date = Date(), permissions: UInt16 = defaultFilePermissions,
                          compressionMethod: CompressionMethod = .none, bufferSize: UInt32 = defaultWriteChunkSize,
                          progress: Progress? = nil, provider: Provider) throws {
         guard self.accessMode != .read else { throw ArchiveError.unwritableArchive }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -15,7 +15,8 @@ public let defaultReadChunkSize = UInt32(16*1024)
 /// The default chunk size when writing entry data to an archive.
 public let defaultWriteChunkSize = defaultReadChunkSize
 /// The default permissions for newly added entries.
-public let defaultPermissions = UInt16(0o644)
+public let defaultFilePermissions = UInt16(0o644)
+public let defaultDirectoryPermissions = UInt16(0o755)
 let defaultPOSIXBufferSize = defaultReadChunkSize
 let defaultDirectoryUnitCount = Int64(1)
 let minDirectoryEndOffset = 22

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -111,7 +111,7 @@ public struct Entry: Equatable {
     ///
     /// Contains the modification date and file permissions.
     public var fileAttributes: [FileAttributeKey: Any] {
-        return FileManager.attributes(from: self.centralDirectoryStructure)
+        return FileManager.attributes(from: self)
     }
     /// The `CRC32` checksum of the receiver.
     ///

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -111,7 +111,7 @@ public struct Entry: Equatable {
     ///
     /// Contains the modification date and file permissions.
     public var fileAttributes: [FileAttributeKey: Any] {
-        return FileManager.attributes(from: self)
+        return FileManager.attributes(from: self.centralDirectoryStructure, for: self.type)
     }
     /// The `CRC32` checksum of the receiver.
     ///

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -124,9 +124,10 @@ extension FileManager {
         }
     }
 
-    class func attributes(from entry: Entry) -> [FileAttributeKey: Any] {
-        let centralDirectoryStructure = entry.centralDirectoryStructure
-        var attributes = [.posixPermissions: entry.type == .directory ? defaultDirectoryPermissions : defaultFilePermissions,
+    class func attributes(from centralDirectoryStructure: CentralDirectoryStructure,
+                          for entryType: Entry.EntryType = .file) -> [FileAttributeKey: Any] {
+        var attributes = [.posixPermissions: entryType ==
+            .directory ? defaultDirectoryPermissions : defaultFilePermissions,
                           .modificationDate: Date()] as [FileAttributeKey: Any]
         let versionMadeBy = centralDirectoryStructure.versionMadeBy
         let fileTime = centralDirectoryStructure.lastModFileTime
@@ -135,13 +136,14 @@ extension FileManager {
             return attributes
         }
         let externalFileAttributes = centralDirectoryStructure.externalFileAttributes
-        let permissions = self.permissions(for: externalFileAttributes, osType: osType, entryType: entry.type)
+        let permissions = self.permissions(for: externalFileAttributes, osType: osType, entryType: entryType)
         attributes[.posixPermissions] = NSNumber(value: permissions)
         attributes[.modificationDate] = Date(dateTime: (fileDate, fileTime))
         return attributes
     }
 
-    class func permissions(for externalFileAttributes: UInt32, osType: Entry.OSType, entryType: Entry.EntryType) -> UInt16 {
+    class func permissions(for externalFileAttributes: UInt32, osType: Entry.OSType,
+                           entryType: Entry.EntryType = .file) -> UInt16 {
         switch osType {
         case .unix, .osx:
             let permissions = mode_t(externalFileAttributes >> 16) & (~S_IFMT)

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -257,7 +257,7 @@ extension ZIPFoundationTests {
         guard let permissions = attributes[.posixPermissions] as? UInt16 else {
             XCTFail("Failed to read file attributes."); return
         }
-        XCTAssert(permissions == defaultPermissions)
+        XCTAssert(permissions == defaultFilePermissions)
     }
 
     func testFilePermissionErrorConditions() {
@@ -273,9 +273,9 @@ extension ZIPFoundationTests {
 
     func testFilePermissionHelperMethods() {
         var permissions = FileManager.permissions(for: UInt32(777), osType: .unix)
-        XCTAssert(permissions == defaultPermissions)
+        XCTAssert(permissions == defaultFilePermissions)
         permissions = FileManager.permissions(for: UInt32(0), osType: .msdos)
-        XCTAssert(permissions == defaultPermissions)
+        XCTAssert(permissions == defaultFilePermissions)
     }
 
     func testFileModificationDateHelperMethods() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -81,7 +81,7 @@ class ZIPFoundationTests: XCTestCase {
         XCTAssertNil(unreadableArchive)
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultPermissions)]
+        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultFilePermissions)]
         result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                                 attributes: fullPermissionAttributes)
         XCTAssert(result == true)

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -277,7 +277,7 @@ extension ZIPFoundationTests {
         let processInfo = ProcessInfo.processInfo
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultPermissions)]
+        let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultFilePermissions)]
         let fileManager = FileManager()
         let result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                                     attributes: fullPermissionAttributes)


### PR DESCRIPTION
Fixes #52 

# Changes proposed in this PR

In this PR, we change the order of extraction to extract all directories first. We also apply different default permissions to directories (`755`) than we do to files (`644`). (Directories are extracted first so that the default directory attributes are set instead of the default file attributes.)

This is done by renaming the existing `defaultPermissions` setting to `defaultFilePermissions`, and introducing a new setting `defaultDirectoryPermissions` and updating the `FileManager.attributes:from:` method to take the entry type into account when returning default permissions. 

# Tests performed

- I verified that archives extracted with this tweaked algorithm have exactly the same file and directory permissions as archives extracted with macOS's `unzip` command line tool.
- I've only tested this thoroughly on macOS. A quick run on iOS seems to work though.
- The unit tests pass

# Further info for the reviewer

Zip files with no defined permissions for files and directories (like the ones that are generated by GitHub's "download archive" feature) cause ZIPFoundation to use its default permissions.

The default permissions are set to `644` in `Archive.swift`. While this is enough for files to be readable and writable, `FileManager` throws a `Permission Denied` error when trying to write into a directory that is not explicitly marked as executable. This caused the error described in #52, which this PR aims to fix.

## Example Project

In the [zip-foundation-fix branch of my tiny Launch Pad project](https://github.com/winsmith/launch-pad/tree/feature/zip-foundation-fix) you'll find a copy of the files embedded in an Xcode project. Run that project, and it will download a zip file and try to extract it. (Output is on the console, please ignore the UI). 

# Open Issues

While Unit Tests pass, swiftlint complains about `Fallthrough Violation: Fallthrough should be avoided. (fallthrough)` on lines I did not touch.