### PR TITLE
Use new function name to allocate bytes in Swift 4.1

### DIFF
--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -57,7 +57,11 @@ extension Data {
     }
 
     static func readChunk(of size: Int, from file: UnsafeMutablePointer<FILE>) throws -> Data {
+        #if swift(>=4.1)
+        let bytes = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: 1)
+        #else
         let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+        #endif
         let bytesRead = fread(bytes, 1, size, file)
         let error = ferror(file)
         if error > 0 {


### PR DESCRIPTION
Swift 4.1 warning message: 'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'

I'm not sure if you want to maintain backwards compatibility for some time, so I changed this function name inside a check on the Swift version.