### PR TITLE
Swift 4.2 support for Swift Package Manager

### DIFF
--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+let dependencies: [Package.Dependency] = []
+#else
+let dependencies: [Package.Dependency] = [.package(url: "https://github.com/IBM-Swift/CZlib.git", .exact("0.1.2"))]
+#endif
+
+let package = Package(
+    name: "ZIPFoundation",
+    products: [
+        .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])
+    ],
+	dependencies: dependencies,
+    targets: [
+        .target(name: "ZIPFoundation"),
+		.testTarget(name: "ZIPFoundationTests", dependencies: ["ZIPFoundation"])
+    ],
+    swiftLanguageVersions: [.v4, .v4_2]
+)


### PR DESCRIPTION
Adds Swift 4.2 support for Swift Package Manager.
Note: when attempting to run tests, I get stuck at `testCreateArchiveAddLargeCompressedEntry`, but this occurs before any of my changes were made.