### PR TITLE
Allow use in app extensions

### DIFF
--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		OBJ_45 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CURRENT_PROJECT_VERSION = 0.9.6;
 				ENABLE_TESTABILITY = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
@@ -429,6 +430,7 @@
 		OBJ_46 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CURRENT_PROJECT_VERSION = 0.9.6;
 				ENABLE_TESTABILITY = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;


### PR DESCRIPTION
Fixes #75

Pretty small change. This allows ZIPFoundation to be imported and used from iOS app extensions. ZIPFoundation is already only using app extension-safe APIs, so it just required enabling this in the project settings.

# Changes proposed in this PR
* Allows use in app extensions by checking "Allow app extension API only" in framework's project settings

# Tests performed
* All tests still pass