### PR TITLE
Remove FileAttributeKeys not supported in swift-corelibs when unzipping file

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -53,8 +53,13 @@ extension Archive {
             }
             checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
         }
-        let attributes = FileManager.attributes(from: entry)
+
+        var attributes = FileManager.attributes(from: entry)
+        #if os(Linux) // Certain keys are not yet supported in swift-corelibs
+        attributes.removeValue(forKey: .modificationDate)
+        #endif
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
+        
         return checksum
     }
 


### PR DESCRIPTION
Fixes #65

# Changes proposed in this PR
* Temporary workaround for attribute not supported on Linux.
