### PR TITLE
Added Swift 5 package manifest with explicit macOS minimum deployment target version

### DIFF
--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+#if canImport(Compression)
+let dependencies: [Package.Dependency] = []
+#else
+let dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/IBM-Swift/CZlib.git", .exact("0.1.2"))
+]
+#endif
+
+let package = Package(
+    name: "ZIPFoundation",
+    platforms: [
+        .macOS(.v10_11)
+    ],
+    products: [
+        .library(
+            name: "ZIPFoundation",
+            targets: ["ZIPFoundation"]
+        )
+    ],
+    dependencies: dependencies,
+    targets: [
+        .target(
+            name: "ZIPFoundation"
+        ),
+        .testTarget(
+            name: "ZIPFoundationTests",
+            dependencies: ["ZIPFoundation"]
+        )
+    ]
+)

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA804C48224552F80006A522 /* Package@swift-5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package@swift-5.swift"; sourceTree = "<group>"; };
 		BA3716A921F0A1AC006E54E6 /* ZIPFoundationProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationProgressTests.swift; sourceTree = "<group>"; };
 		OBJ_10 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
 		OBJ_11 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
@@ -112,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
+				AA804C48224552F80006A522 /* Package@swift-5.swift */,
 				OBJ_7 /* Sources */,
 				OBJ_16 /* Tests */,
 				OBJ_25 /* Products */,
@@ -199,6 +201,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = OBJ_5;


### PR DESCRIPTION
- With this change you can now build ZIPFoundation on macOS with just `swift build`

