### PR TITLE
Swift 5 support for podspec and Xcode project file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## [0.9.9](https://github.com/weichsel/ZIPFoundation/releases/tag/0.9.10)
+
+### Updated
+ - Swift 5.0 support in Xcode project and podspec file
+
 ## [0.9.9](https://github.com/weichsel/ZIPFoundation/releases/tag/0.9.9)
 
 ### Added
  - Swift 5.0 support
  - Optional `preferredEncoding` parameter to explicitly configure an encoding for filepaths
- 
+
 ### Updated
  - Fixed a library load error related to dylib versioning
  - Fixed a hang during read when decoding small, `.deflate` compressed entries
@@ -22,7 +27,7 @@
 ### Added
  - App extension support
  - Optional `compressionMethod` parameter for `zipItem:`
- 
+
 ### Updated
  - Fixed a path traversal attack vulnerability
  - Fixed a crash due to wrong error handling after failed `fopen` calls
@@ -34,7 +39,7 @@
 
 ### Added
  - Swift 4.1 support
- 
+
 ### Updated
  - Fixed default directory permissions
  - Fixed a compile issue when targeting Linux
@@ -44,7 +49,7 @@
 ### Added
  - Progress tracking support
  - Operation cancellation support
- 
+
 ### Updated
  - Improved performance of CRC32 calculations
  - Improved Linux support
@@ -61,7 +66,7 @@
 
 ### Added
  - Carthage support
- 
+
 ### Updated
  - Improved error handling
  - Made consistent use of Swift's `CocoaError` instead of `NSError`
@@ -77,15 +82,15 @@
 
 ### Added
  - Optional parameter to skip CRC32 checksum calculation
- 
+
 ### Updated
  - Tweaked POSIX buffer sizes to improve IO and comrpression performance
  - Improved source readability
  - Refined documentation
- 
+
 ### Removed
  - Optional parameter skip decompression during entry retrieval
- 
+
 ## [0.9.0](https://github.com/weichsel/ZIPFoundation/releases/tag/0.9.0)
 
 ### Added

--- a/ZIPFoundation.podspec
+++ b/ZIPFoundation.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name = 'ZIPFoundation'
-  s.version = '0.9.9'
+  s.version = '0.9.10'
   s.license = 'MIT'
   s.summary = 'Effortless ZIP Handling in Swift'
   s.homepage = 'https://github.com/weichsel/ZIPFoundation'
   s.social_media_url = 'http://twitter.com/weichsel'
   s.authors = { 'Thomas Zoechling' => 'thomas@peakstep.com' }
   s.source = { :git => 'https://github.com/weichsel/ZIPFoundation.git', :tag => s.version }
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ZIPFoundationTests;
 			};
 			name = Debug;
@@ -354,6 +355,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ZIPFoundationTests;
 			};
 			name = Release;
@@ -428,6 +430,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ZIPFoundation;
 			};
 			name = Debug;
@@ -454,6 +457,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = ZIPFoundation;
 			};
 			name = Release;


### PR DESCRIPTION
Fixes #

# Changes proposed in this PR
* Swift 5 support for podspec and Xcode project file

# Tests performed


# Further info for the reviewer
Nothing else has been changed.

# Open Issues
