### PR TITLE
Levi/108

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -327,7 +327,7 @@ extension Archive {
         _ = try Data.write(chunk: endOfCentralDirRecord.data, to: self.archiveFile)
     }
 
-    private func replaceCurrentArchiveWithArchive(at URL: URL) throws {
+    func replaceCurrentArchiveWithArchive(at URL: URL) throws {
         fclose(self.archiveFile)
         let fileManager = FileManager()
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -146,7 +146,7 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
-        let tempDir = uniqueTemporaryDirectoryURL()
+        let tempDir = self.uniqueTemporaryDirectoryURL()
         defer { try? FileManager().removeItem(at: tempDir) }
         do { try FileManager().createParentDirectoryStructure(for: tempDir) } catch { throw ArchiveError.unwritableArchive }
         let uniqueString = ProcessInfo.processInfo.globallyUniqueString

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -146,12 +146,14 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
+		let manager = FileManager()
         let tempDir = self.uniqueTemporaryDirectoryURL()
-        defer { try? FileManager().removeItem(at: tempDir) }
-        do { try FileManager().createParentDirectoryStructure(for: tempDir) } catch {
-            throw ArchiveError.unwritableArchive }
-        let uniqueString = ProcessInfo.processInfo.globallyUniqueString
-        guard let tempArchive = Archive(url: tempDir.appendingPathComponent(uniqueString), accessMode: .create) else {
+        defer { try? manager.removeItem(at: tempDir) }
+		let uniqueString = ProcessInfo.processInfo.globallyUniqueString
+		let tempArchiveURL =  tempDir.appendingPathComponent(uniqueString)
+        do { try manager.createParentDirectoryStructure(for: tempArchiveURL) } catch {
+			throw ArchiveError.unwritableArchive }
+        guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
             throw ArchiveError.unwritableArchive
         }
         progress?.totalUnitCount = self.totalUnitCountForRemoving(entry)

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -146,8 +146,13 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
-        let uniqueString = ProcessInfo.processInfo.globallyUniqueString
-        let tempArchiveURL =  URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(uniqueString)
+		let tempArchiveURL = (try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
+														   appropriateFor: self.url, create: true))
+			?? URL(fileURLWithPath: NSTemporaryDirectory())
+				.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+		defer {
+			try? FileManager().removeItem(at: tempArchiveURL)
+		}
         guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
             throw ArchiveError.unwritableArchive
         }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -196,9 +196,9 @@ extension Archive {
 		if let tempDir = try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
 												appropriateFor: self.url, create: true) {
 			return tempDir
-		} else {
-			return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
 		}
+		
+		return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
     }
 
 	private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -195,7 +195,7 @@ extension Archive {
     // MARK: - Helpers
 
     func uniqueTemporaryDirectoryURL() -> URL {
-        #if swift(>=5.0)
+        #if swift(>=5.0) || os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         if let tempDir = try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
                                                 appropriateFor: self.url, create: true) {
             return tempDir

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -148,7 +148,8 @@ extension Archive {
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
         let tempDir = self.uniqueTemporaryDirectoryURL()
         defer { try? FileManager().removeItem(at: tempDir) }
-        do { try FileManager().createParentDirectoryStructure(for: tempDir) } catch { throw ArchiveError.unwritableArchive }
+        do { try FileManager().createParentDirectoryStructure(for: tempDir) } catch {
+            throw ArchiveError.unwritableArchive }
         let uniqueString = ProcessInfo.processInfo.globallyUniqueString
         guard let tempArchive = Archive(url: tempDir.appendingPathComponent(uniqueString), accessMode: .create) else {
             throw ArchiveError.unwritableArchive

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -192,16 +192,16 @@ extension Archive {
 
     // MARK: - Helpers
 
-	func uniqueTemporaryDirectoryURL() -> URL {
-		if let tempDir = try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
-												appropriateFor: self.url, create: true) {
-			return tempDir
-		}
-		
-		return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    func uniqueTemporaryDirectoryURL() -> URL {
+        if let tempDir = try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
+                                                appropriateFor: self.url, create: true) {
+            return tempDir
+        }
+
+        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
     }
 
-	private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,
+    private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,
                                       size: (uncompressed: UInt32, compressed: UInt32),
                                       checksum: CRC32,
                                       modificationDateTime: (UInt16, UInt16)) throws -> LocalFileHeader {
@@ -331,12 +331,12 @@ extension Archive {
         fclose(self.archiveFile)
         let fileManager = FileManager()
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        do {
-            _ = try fileManager.replaceItemAt(self.url, withItemAt: URL)
-        } catch {
-            _ = try fileManager.removeItem(at: self.url)
-            _ = try fileManager.moveItem(at: URL, to: self.url)
-        }
+            do {
+                _ = try fileManager.replaceItemAt(self.url, withItemAt: URL)
+            } catch {
+                _ = try fileManager.removeItem(at: self.url)
+                _ = try fileManager.moveItem(at: URL, to: self.url)
+            }
         #else
             _ = try fileManager.removeItem(at: self.url)
             _ = try fileManager.moveItem(at: URL, to: self.url)
@@ -345,3 +345,4 @@ extension Archive {
         self.archiveFile = fopen(fileSystemRepresentation, "rb+")
     }
 }
+

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -66,7 +66,7 @@ extension Archive {
                 let linkFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: linkDestination)
                 let linkLength = Int(strlen(linkFileSystemRepresentation))
                 let linkBuffer = UnsafeBufferPointer(start: linkFileSystemRepresentation, count: linkLength)
-                return Data.init(buffer: linkBuffer)
+                return Data(buffer: linkBuffer)
             }
             try self.addEntry(with: path, type: type, uncompressedSize: uncompressedSize,
                               modificationDate: modDate, permissions: permissions,
@@ -214,7 +214,7 @@ extension Archive {
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: path)
         let fileNameLength = Int(strlen(fileSystemRepresentation))
         let fileNameBuffer = UnsafeBufferPointer(start: fileSystemRepresentation, count: fileNameLength)
-        let fileNameData = Data.init(buffer: fileNameBuffer)
+        let fileNameData = Data(buffer: fileNameBuffer)
         let localFileHeader = LocalFileHeader(versionNeededToExtract: UInt16(20), generalPurposeBitFlag: UInt16(2048),
                                               compressionMethod: compressionMethod.rawValue,
                                               lastModFileTime: modificationDateTime.1,

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -147,6 +147,11 @@ extension Archive {
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
         let tempDir = uniqueTemporaryDirectoryURL()
+		do {
+			try FileManager().createParentDirectoryStructure(for: tempDir)
+		} catch {
+			throw ArchiveError.unwritableArchive
+		}
         defer {
             try? FileManager().removeItem(at: tempDir)
         }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -146,13 +146,7 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
-		let tempArchiveURL = (try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
-														   appropriateFor: self.url, create: true))
-			?? URL(fileURLWithPath: NSTemporaryDirectory())
-				.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
-		defer {
-			try? FileManager().removeItem(at: tempArchiveURL)
-		}
+        let tempArchiveURL = createTempArchiveURL()
         guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
             throw ArchiveError.unwritableArchive
         }
@@ -194,6 +188,14 @@ extension Archive {
 
     // MARK: - Helpers
 
+    func createTempArchiveURL() -> URL {
+        let tempArchiveURL = ((try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
+                                                      appropriateFor: self.url, create: true))
+            ?? URL(fileURLWithPath: NSTemporaryDirectory()))
+            .appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        return tempArchiveURL
+    }
+    
     private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,
                                       size: (uncompressed: UInt32, compressed: UInt32),
                                       checksum: CRC32,

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -345,4 +345,3 @@ extension Archive {
         self.archiveFile = fopen(fileSystemRepresentation, "rb+")
     }
 }
-

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -147,14 +147,8 @@ extension Archive {
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
         let tempDir = uniqueTemporaryDirectoryURL()
-		do {
-			try FileManager().createParentDirectoryStructure(for: tempDir)
-		} catch {
-			throw ArchiveError.unwritableArchive
-		}
-        defer {
-            try? FileManager().removeItem(at: tempDir)
-        }
+        defer { try? FileManager().removeItem(at: tempDir) }
+        do { try FileManager().createParentDirectoryStructure(for: tempDir) } catch { throw ArchiveError.unwritableArchive }
         let uniqueString = ProcessInfo.processInfo.globallyUniqueString
         guard let tempArchive = Archive(url: tempDir.appendingPathComponent(uniqueString), accessMode: .create) else {
             throw ArchiveError.unwritableArchive
@@ -203,7 +197,8 @@ extension Archive {
             return tempDir
         }
 
-        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
+            ProcessInfo.processInfo.globallyUniqueString)
     }
 
     private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -326,7 +326,12 @@ extension Archive {
         fclose(self.archiveFile)
         let fileManager = FileManager()
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        do {
             _ = try fileManager.replaceItemAt(self.url, withItemAt: URL)
+        } catch {
+            _ = try fileManager.removeItem(at: self.url)
+            _ = try fileManager.moveItem(at: URL, to: self.url)
+        }
         #else
             _ = try fileManager.removeItem(at: self.url)
             _ = try fileManager.moveItem(at: URL, to: self.url)

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -192,10 +192,12 @@ extension Archive {
     // MARK: - Helpers
 
     func uniqueTemporaryDirectoryURL() -> URL {
+        #if swift(>=5.0)
         if let tempDir = try? FileManager().url(for: .itemReplacementDirectory, in: .userDomainMask,
                                                 appropriateFor: self.url, create: true) {
             return tempDir
         }
+        #endif
 
         return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
             ProcessInfo.processInfo.globallyUniqueString)

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -152,7 +152,6 @@ public final class Archive: Sequence {
             self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
         case .create:
             guard !fileManager.fileExists(atPath: url.path) else { return nil }
-            do { try fileManager.createParentDirectoryStructure(for: url) } catch { return nil }
             let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(numberOfDisk: 0, numberOfDiskStart: 0,
                                                                           totalNumberOfEntriesOnDisk: 0,
                                                                           totalNumberOfEntriesInCentralDirectory: 0,

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -152,6 +152,7 @@ public final class Archive: Sequence {
             self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
         case .create:
             guard !fileManager.fileExists(atPath: url.path) else { return nil }
+            do { try fileManager.createParentDirectoryStructure(for: url) } catch { return nil }
             let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(numberOfDisk: 0, numberOfDiskStart: 0,
                                                                           totalNumberOfEntriesOnDisk: 0,
                                                                           totalNumberOfEntriesInCentralDirectory: 0,

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -130,9 +130,7 @@ extension FileManager {
 
     func createParentDirectoryStructure(for url: URL) throws {
         let parentDirectoryURL = url.deletingLastPathComponent()
-        if !self.fileExists(atPath: parentDirectoryURL.path) {
-            try self.createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true, attributes: nil)
-        }
+        try self.createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true, attributes: nil)
     }
 
     class func attributes(from entry: Entry) -> [FileAttributeKey: Any] {

--- a/Tests/ZIPFoundationTests/ZIPFoundationEntryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationEntryTests.swift
@@ -28,7 +28,7 @@ extension ZIPFoundationTests {
     }
 
     func testEntryInvalidSignatureErrorConditions() {
-        let invalidCDS = Entry.CentralDirectoryStructure(data: Data.init(count: Entry.CentralDirectoryStructure.size),
+        let invalidCDS = Entry.CentralDirectoryStructure(data: Data(count: Entry.CentralDirectoryStructure.size),
                                                          additionalDataProvider: {_ -> Data in
                                                             return Data() })
         XCTAssertNil(invalidCDS)

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -346,4 +346,20 @@ extension ZIPFoundationTests {
         }
         XCTFail("Extraction should fail")
     }
+
+    func testUniqueTemporaryDirectoryURL() {
+        let archive = self.archive(for: #function, mode: .create)
+        var tempURLs = Set<URL>()
+        defer {
+            for url in tempURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+        // We choose 2000 temp directories to test workaround for http://openradar.appspot.com/50553219
+        for _ in 1...2000 {
+            let tempDir = archive.uniqueTemporaryDirectoryURL()
+            XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
+            tempURLs.insert(tempDir)
+        }
+    }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -160,7 +160,7 @@ extension ZIPFoundationTests {
             fseek(destinationFile, 64, SEEK_SET)
             // We have to inject a large enough zeroes block to guarantee that libcompression 
             // detects the failure when reading the stream
-            _ = try Data.write(chunk: Data.init(count: 512*1024), to: destinationFile)
+            _ = try Data.write(chunk: Data(count: 512*1024), to: destinationFile)
             fclose(destinationFile)
             guard let archive = Archive(url: archiveURL, accessMode: .read) else {
                 XCTFail("Failed to read archive.")

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -319,6 +319,7 @@ extension ZIPFoundationTests {
             ("testZipItemProgress", testZipItemProgress),
             ("testUnzipItemProgress", testUnzipItemProgress),
             ("testRemoveEntryProgress", testRemoveEntryProgress),
+            ("testReplaceCurrentArchiveWithArchive", testReplaceCurrentArchiveWithArchive),
             ("testArchiveAddUncompressedEntryProgress", testArchiveAddUncompressedEntryProgress),
             ("testArchiveAddCompressedEntryProgress", testArchiveAddCompressedEntryProgress),
             // The below test cases test error code paths but they lead to undefined behavior and memory

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -301,11 +301,12 @@ extension ZIPFoundationTests {
             ("testRemoveDataDescriptorCompressedEntry", testRemoveDataDescriptorCompressedEntry),
             ("testRemoveEntryErrorConditions", testRemoveEntryErrorConditions),
             ("testRemoveUncompressedEntry", testRemoveUncompressedEntry),
+            ("testUniqueTemporaryDirectoryURL", testUniqueTemporaryDirectoryURL),
+            ("testTraversalAttack", testTraversalAttack),
             ("testUnzipItem", testUnzipItem),
             ("testUnzipItemWithPreferredEncoding", testUnzipItemWithPreferredEncoding),
             ("testUnzipItemErrorConditions", testUnzipItemErrorConditions),
             ("testZipItem", testZipItem),
-            ("testTraversalAttack", testTraversalAttack),
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
         ] + darwinOnlyTests
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -319,7 +319,7 @@ extension ZIPFoundationTests {
             ("testZipItemProgress", testZipItemProgress),
             ("testUnzipItemProgress", testUnzipItemProgress),
             ("testRemoveEntryProgress", testRemoveEntryProgress),
-            ("testReplaceCurrentArchiveWithArchive", testReplaceCurrentArchiveWithArchive),
+            ("testReplaceCurrentArchiveWithArchiveCrossLink", testReplaceCurrentArchiveWithArchiveCrossLink),
             ("testArchiveAddUncompressedEntryProgress", testArchiveAddUncompressedEntryProgress),
             ("testArchiveAddCompressedEntryProgress", testArchiveAddCompressedEntryProgress),
             // The below test cases test error code paths but they lead to undefined behavior and memory

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -392,7 +392,7 @@ extension ZIPFoundationTests {
         try script.write(to: scriptURL, atomically: false, encoding: .utf8)
         let permissions = NSNumber(value: Int16(0o770))
         try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: scriptURL.path)
-        let task = try NSUserScriptTask.init(url: scriptURL)
+        let task = try NSUserScriptTask(url: scriptURL)
         return task
     }
     #endif

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -386,14 +386,14 @@ extension ZIPFoundationTests {
         let dmgURL = tempDir.appendingPathComponent(volumeName).appendingPathExtension("dmg")
         let script = """
         #!/bin/bash
-        hdiutil create -size 5m -fs HFS+ -type SPARSEBUNDLE -ov -attach -volname "\(volumeName)" "\(dmgURL.path)"
+        hdiutil create -size 5m -fs HFS+ -type SPARSEBUNDLE -ov -volname "\(volumeName)" "\(dmgURL.path)"
+        hdiutil attach -nobrowse "\(dmgURL.appendingPathExtension("sparsebundle").path)"
 
         """
         try script.write(to: scriptURL, atomically: false, encoding: .utf8)
         let permissions = NSNumber(value: Int16(0o770))
         try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: scriptURL.path)
-        let task = try NSUserScriptTask(url: scriptURL)
-        return task
+        return try NSUserScriptTask(url: scriptURL)
     }
     #endif
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -340,11 +340,9 @@ extension ZIPFoundationTests {
         }
         // We choose 2000 temp directories to test workaround for http://openradar.appspot.com/50553219
         for _ in 1...2000 {
-            autoreleasepool {
-                let tempDir = archive.uniqueTemporaryDirectoryURL()
-                XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
-                tempURLs.insert(tempDir)
-            }
+            let tempDir = archive.uniqueTemporaryDirectoryURL()
+            XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
+            tempURLs.insert(tempDir)
         }
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -329,4 +329,15 @@ extension ZIPFoundationTests {
         let nonUpdatableArchive = Archive(url: nonUpdatableArchiveURL, accessMode: .update)
         XCTAssertNil(nonUpdatableArchive)
     }
+
+    func testTemporaryArchiveURLCreation() {
+        let archive = self.archive(for: #function, mode: .create)
+        var tempURLs = Set<URL>()
+        // We choose 2000 temp directories to test workaround for http://openradar.appspot.com/50553219
+        for _ in 1...2000 {
+            let tempArchiveURL = archive.createTempArchiveURL()
+            XCTAssertFalse(tempURLs.contains(tempArchiveURL), "Temp archive URL should be unique. \(tempArchiveURL)")
+            tempURLs.insert(tempArchiveURL)
+        }
+    }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -349,6 +349,7 @@ extension ZIPFoundationTests {
     }
 
     func testReplaceCurrentArchiveWithArchiveCrossLink() {
+		#if os(macOS)
         let createVolumeExpectation = expectation(description: "Creation of temporary additional volume")
         let unmountVolumeExpectation = expectation(description: "Unmount temporary additional volume")
 
@@ -422,5 +423,6 @@ extension ZIPFoundationTests {
         }
 
         waitForExpectations(timeout: 30.0)
+		#endif
     }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -54,9 +54,7 @@ extension ZIPFoundationTests {
         let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(uniqueString)
         do {
             let fileManager = FileManager()
-            try fileManager.createDirectory(at: tempDirectoryURL,
-                                            withIntermediateDirectories: true,
-                                            attributes: nil)
+            try fileManager.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true, attributes: nil)
             let relativePath = tempDirectoryURL.lastPathComponent
             let baseURL = tempDirectoryURL.deletingLastPathComponent()
             try archive.addEntry(with: relativePath + "/", relativeTo: baseURL)
@@ -382,6 +380,7 @@ extension ZIPFoundationTests {
 		#endif
     }
 
+    #if os(macOS)
     private func makeVolumeCreationTask(at tempDir: URL, volumeName: String) throws -> NSUserScriptTask {
         let scriptURL = tempDir.appendingPathComponent("createVol.sh", isDirectory: false)
         let dmgURL = tempDir.appendingPathComponent(volumeName).appendingPathExtension("dmg")
@@ -396,4 +395,5 @@ extension ZIPFoundationTests {
         let task = try NSUserScriptTask.init(url: scriptURL)
         return task
     }
+    #endif
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -332,19 +332,19 @@ extension ZIPFoundationTests {
 
     func testUniqueTemporaryDirectoryURL() {
         let archive = self.archive(for: #function, mode: .create)
-		var tempURLs = Set<URL>()
-		defer {
-			for url in tempURLs {
-				try? FileManager.default.removeItem(at: url)
-			}
-		}
+        var tempURLs = Set<URL>()
+        defer {
+            for url in tempURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
         // We choose 2000 temp directories to test workaround for http://openradar.appspot.com/50553219
         for _ in 1...2000 {
-			autoreleasepool {
-				let tempDir = archive.uniqueTemporaryDirectoryURL()
-				XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
-				tempURLs.insert(tempDir)
-			}
+            autoreleasepool {
+                let tempDir = archive.uniqueTemporaryDirectoryURL()
+                XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
+                tempURLs.insert(tempDir)
+            }
         }
     }
 
@@ -373,7 +373,8 @@ extension ZIPFoundationTests {
         let scriptURL = tempDir.appendingPathComponent("createVol.sh", isDirectory: false)
         do {
             try script.write(to: scriptURL, atomically: false, encoding: .utf8)
-            try FileManager.default.setAttributes([.posixPermissions: 0o770], ofItemAtPath: scriptURL.path)
+            let permissions = NSNumber(value: Int16(0o770))
+            try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: scriptURL.path)
             let task = try NSUserScriptTask.init(url: scriptURL)
             task.execute { (error) in
                 guard error == nil else {
@@ -383,13 +384,13 @@ extension ZIPFoundationTests {
                 let vol2URL = URL(fileURLWithPath: "/Volumes/\(volName)")
 
                 defer {
-                    FileManager.default.unmountVolume(at: vol2URL, options: [.allPartitionsAndEjectDisk, .withoutUI], completionHandler: {
-                        (error) in
-                        guard error == nil else {
-                            XCTFail("\(String(describing: error))")
-                            return
-                        }
-                        unmountVolumeExpectation.fulfill()
+                    FileManager.default.unmountVolume(at: vol2URL, options:
+                        [.allPartitionsAndEjectDisk, .withoutUI], completionHandler: { (error) in
+                            guard error == nil else {
+                                XCTFail("\(String(describing: error))")
+                                return
+                            }
+                            unmountVolumeExpectation.fulfill()
                     })
                 }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -330,14 +330,21 @@ extension ZIPFoundationTests {
         XCTAssertNil(nonUpdatableArchive)
     }
 
-    func testTemporaryArchiveURLCreation() {
+    func testUniqueTemporaryDirectoryURL() {
         let archive = self.archive(for: #function, mode: .create)
-        var tempURLs = Set<URL>()
+		var tempURLs = Set<URL>()
+		defer {
+			for url in tempURLs {
+				try? FileManager.default.removeItem(at: url)
+			}
+		}
         // We choose 2000 temp directories to test workaround for http://openradar.appspot.com/50553219
         for _ in 1...2000 {
-            let tempArchiveURL = archive.createTempArchiveURL()
-            XCTAssertFalse(tempURLs.contains(tempArchiveURL), "Temp archive URL should be unique. \(tempArchiveURL)")
-            tempURLs.insert(tempArchiveURL)
+			autoreleasepool {
+				let tempDir = archive.uniqueTemporaryDirectoryURL()
+				XCTAssertFalse(tempURLs.contains(tempDir), "Temp directory URL should be unique. \(tempDir)")
+				tempURLs.insert(tempDir)
+			}
         }
     }
 }


### PR DESCRIPTION
Fixes #108 

# Changes proposed in this PR
* Using modern temporary directory mechanism, with fallback if needed.
* Addresses archive replacement issue when archives reside on different volumes.
* Removed `fileExists` check when creating directory as this is contrary to recommended practice.

# Tests performed
* Added test for temporary directory creation mechanism.
* Added test for cross-link (separate volume) archive replacement changes.

# Further info for the reviewer
* Opened up `private` methods to `internal` (implicit) for testing purposes.
* Maintained 100% code coverage and no swiftlint issues as per contribution guidelines.
