### PR TITLE
Levi/racecondition

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -141,8 +141,6 @@ public final class Archive: Sequence {
         let fileManager = FileManager()
         switch mode {
         case .read:
-            guard fileManager.fileExists(atPath: url.path) else { return nil }
-            guard fileManager.isReadableFile(atPath: url.path) else { return nil }
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
             guard let archiveFile = fopen(fileSystemRepresentation, "rb"),
                 let endOfCentralDirectoryRecord = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
@@ -165,7 +163,6 @@ public final class Archive: Sequence {
             }
             fallthrough
         case .update:
-            guard fileManager.isWritableFile(atPath: url.path) else { return nil }
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
             guard let archiveFile = fopen(fileSystemRepresentation, "rb+"),
                 let endOfCentralDirectoryRecord = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -151,7 +151,6 @@ public final class Archive: Sequence {
             self.archiveFile = archiveFile
             self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
         case .create:
-            guard !fileManager.fileExists(atPath: url.path) else { return nil }
             let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(numberOfDisk: 0, numberOfDiskStart: 0,
                                                                           totalNumberOfEntriesOnDisk: 0,
                                                                           totalNumberOfEntriesInCentralDirectory: 0,
@@ -159,8 +158,11 @@ public final class Archive: Sequence {
                                                                           offsetToStartOfCentralDirectory: 0,
                                                                           zipFileCommentLength: 0,
                                                                           zipFileCommentData: Data())
-            guard fileManager.createFile(atPath: url.path, contents: endOfCentralDirectoryRecord.data,
-                                         attributes: nil) else { return nil }
+            do {
+                try endOfCentralDirectoryRecord.data.write(to: url, options: .withoutOverwriting)
+            } catch {
+                return nil
+            }
             fallthrough
         case .update:
             guard fileManager.isWritableFile(atPath: url.path) else { return nil }


### PR DESCRIPTION
This fixes a witnessed race condition with filesystem access when running optimized code on macOS which prevented the `createFile` function from being successful. This also addresses other similar potential issues by removing unnecessary calls to file system functions in the `init` method.