### PR TITLE
Exposed skipCRC32 flag to public API when reading/unzipping an archive.

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -17,10 +17,11 @@ extension Archive {
     ///   - entry: The ZIP `Entry` to read.
     ///   - url: The destination file URL.
     ///   - bufferSize: The maximum size of the read buffer and the decompression buffer (if needed).
+    ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to speed up performance.
     ///   - progress: A progress object that can be used to track or cancel the extract operation.
-    /// - Returns: The checksum of the processed content.
+    /// - Returns: The checksum of the processed content or 0 if the `skipCRC32` flag was set to `true`.
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, to url: URL, bufferSize: UInt32 = defaultReadChunkSize,
+    public func extract(_ entry: Entry, to url: URL, bufferSize: UInt32 = defaultReadChunkSize, skipCRC32: Bool = false,
                         progress: Progress? = nil) throws -> CRC32 {
         let fileManager = FileManager()
         var checksum = CRC32(0)
@@ -36,12 +37,12 @@ extension Archive {
             }
             defer { fclose(destinationFile) }
             let consumer = { _ = try Data.write(chunk: $0, to: destinationFile) }
-            checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32, progress: progress, consumer: consumer)
         case .directory:
             let consumer = { (_: Data) in
                 try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
             }
-            checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32, progress: progress, consumer: consumer)
         case .symlink:
             guard !fileManager.fileExists(atPath: url.path) else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
@@ -51,7 +52,7 @@ extension Archive {
                 try fileManager.createParentDirectoryStructure(for: url)
                 try fileManager.createSymbolicLink(atPath: url.path, withDestinationPath: linkPath)
             }
-            checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
+            checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32, progress: progress, consumer: consumer)
         }
         let attributes = FileManager.attributes(from: entry)
         try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
@@ -63,11 +64,12 @@ extension Archive {
     /// - Parameters:
     ///   - entry: The ZIP `Entry` to read.
     ///   - bufferSize: The maximum size of the read buffer and the decompression buffer (if needed).
+    ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to speed up performance.
     ///   - progress: A progress object that can be used to track or cancel the extract operation.
     ///   - consumer: A closure that consumes contents of `Entry` as `Data` chunks.
-    /// - Returns: The checksum of the processed content.
+    /// - Returns: The checksum of the processed content or 0 if the `skipCRC32` flag was set to `true`..
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize,
+    public func extract(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, skipCRC32: Bool = false,
                         progress: Progress? = nil, consumer: Consumer) throws -> CRC32 {
         var checksum = CRC32(0)
         let localFileHeader = entry.localFileHeader
@@ -79,9 +81,9 @@ extension Archive {
                 throw ArchiveError.invalidCompressionMethod
             }
             switch compressionMethod {
-            case .none: checksum = try self.readUncompressed(entry: entry, bufferSize: bufferSize,
+            case .none: checksum = try self.readUncompressed(entry: entry, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                                              progress: progress, with: consumer)
-            case .deflate: checksum = try self.readCompressed(entry: entry, bufferSize: bufferSize,
+            case .deflate: checksum = try self.readCompressed(entry: entry, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                                               progress: progress, with: consumer)
             }
         case .directory:
@@ -100,10 +102,10 @@ extension Archive {
 
     // MARK: - Helpers
 
-    private func readUncompressed(entry: Entry, bufferSize: UInt32,
+    private func readUncompressed(entry: Entry, bufferSize: UInt32, skipCRC32: Bool,
                                   progress: Progress? = nil, with consumer: Consumer) throws -> CRC32 {
         let size = Int(entry.centralDirectoryStructure.uncompressedSize)
-        return try Data.consumePart(of: size, chunkSize: Int(bufferSize), provider: { (_, chunkSize) -> Data in
+        return try Data.consumePart(of: size, chunkSize: Int(bufferSize), skipCRC32: skipCRC32, provider: { (_, chunkSize) -> Data in
             return try Data.readChunk(of: Int(chunkSize), from: self.archiveFile)
         }, consumer: { (data) in
             if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
@@ -112,10 +114,10 @@ extension Archive {
         })
     }
 
-    private func readCompressed(entry: Entry, bufferSize: UInt32,
+    private func readCompressed(entry: Entry, bufferSize: UInt32, skipCRC32: Bool,
                                 progress: Progress? = nil, with consumer: Consumer) throws -> CRC32 {
         let size = Int(entry.centralDirectoryStructure.compressedSize)
-        return try Data.decompress(size: size, bufferSize: Int(bufferSize), provider: { (_, chunkSize) -> Data in
+        return try Data.decompress(size: size, bufferSize: Int(bufferSize), skipCRC32: skipCRC32, provider: { (_, chunkSize) -> Data in
             return try Data.readChunk(of: chunkSize, from: self.archiveFile)
         }, consumer: { (data) in
             if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -187,16 +187,14 @@ extension Data {
                     }
                 }
                 if operation == COMPRESSION_STREAM_ENCODE && !skipCRC32 {
-                    checksum = sourceData.crc32(checksum: checksum)
-                }
+                    checksum = sourceData.crc32(checksum: checksum) }
             }
             switch status {
             case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
                 let outputData = Data(bytesNoCopy: destPointer, count: bufferSize - stream.dst_size, deallocator: .none)
                 try consumer(outputData)
                 if operation == COMPRESSION_STREAM_DECODE && !skipCRC32 {
-                    checksum = outputData.crc32(checksum: checksum)
-                }
+                    checksum = outputData.crc32(checksum: checksum) }
                 stream.dst_ptr = destPointer
                 stream.dst_size = bufferSize
             default: throw CompressionError.corruptedData

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -134,10 +134,11 @@ extension Data {
         #endif
     }
 
-    static func decompress(size: Int, bufferSize: Int, skipCRC32: Bool, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    static func decompress(size: Int, bufferSize: Int, skipCRC32: Bool,
+                           provider: Provider, consumer: Consumer) throws -> CRC32 {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize, skipCRC32: skipCRC32,
-                                provider: provider, consumer: consumer)
+        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
+                                skipCRC32: skipCRC32, provider: provider, consumer: consumer)
         #else
         return try self.decode(bufferSize: bufferSize, skipCRC32: skipCRC32, provider: provider, consumer: consumer)
         #endif
@@ -185,13 +186,17 @@ extension Data {
                         status = compression_stream_process(&stream, flags)
                     }
                 }
-                if operation == COMPRESSION_STREAM_ENCODE && !skipCRC32 { checksum = sourceData.crc32(checksum: checksum) }
+                if operation == COMPRESSION_STREAM_ENCODE && !skipCRC32 {
+                    checksum = sourceData.crc32(checksum: checksum)
+                }
             }
             switch status {
             case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
                 let outputData = Data(bytesNoCopy: destPointer, count: bufferSize - stream.dst_size, deallocator: .none)
                 try consumer(outputData)
-                if operation == COMPRESSION_STREAM_DECODE && !skipCRC32 { checksum = outputData.crc32(checksum: checksum) }
+                if operation == COMPRESSION_STREAM_DECODE && !skipCRC32 {
+                    checksum = outputData.crc32(checksum: checksum)
+                }
                 stream.dst_ptr = destPointer
                 stream.dst_size = bufferSize
             default: throw CompressionError.corruptedData

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -134,12 +134,12 @@ extension Data {
         #endif
     }
 
-    static func decompress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    static func decompress(size: Int, bufferSize: Int, skipCRC32: Bool, provider: Provider, consumer: Consumer) throws -> CRC32 {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
+        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                 provider: provider, consumer: consumer)
         #else
-        return try self.decode(bufferSize: bufferSize, provider: provider, consumer: consumer)
+        return try self.decode(bufferSize: bufferSize, skipCRC32: skipCRC32, provider: provider, consumer: consumer)
         #endif
     }
 }
@@ -150,7 +150,7 @@ extension Data {
 import Compression
 
 extension Data {
-    static func process(operation: compression_stream_operation, size: Int, bufferSize: Int,
+    static func process(operation: compression_stream_operation, size: Int, bufferSize: Int, skipCRC32: Bool = false,
                         provider: Provider, consumer: Consumer) throws -> CRC32 {
         var checksum = CRC32(0)
         let destPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
@@ -185,13 +185,13 @@ extension Data {
                         status = compression_stream_process(&stream, flags)
                     }
                 }
-                if operation == COMPRESSION_STREAM_ENCODE { checksum = sourceData.crc32(checksum: checksum) }
+                if operation == COMPRESSION_STREAM_ENCODE && !skipCRC32 { checksum = sourceData.crc32(checksum: checksum) }
             }
             switch status {
             case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
                 let outputData = Data(bytesNoCopy: destPointer, count: bufferSize - stream.dst_size, deallocator: .none)
                 try consumer(outputData)
-                if operation == COMPRESSION_STREAM_DECODE { checksum = outputData.crc32(checksum: checksum) }
+                if operation == COMPRESSION_STREAM_DECODE && !skipCRC32 { checksum = outputData.crc32(checksum: checksum) }
                 stream.dst_ptr = destPointer
                 stream.dst_size = bufferSize
             default: throw CompressionError.corruptedData
@@ -250,7 +250,7 @@ extension Data {
         return zipCRC32
     }
 
-    static func decode(bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    static func decode(bufferSize: Int, skipCRC32: Bool, provider: Provider, consumer: Consumer) throws -> CRC32 {
         var stream = z_stream()
         let streamSize = Int32(MemoryLayout<z_stream>.size)
         var result = inflateInit2_(&stream, -MAX_WBITS, ZLIB_VERSION, streamSize)
@@ -288,7 +288,7 @@ extension Data {
                 let remainingLength = UInt32(bufferSize) - stream.avail_out
                 outputData.count = Int(remainingLength)
                 try consumer(outputData)
-                unzipCRC32 = outputData.crc32(checksum: unzipCRC32)
+                if !skipCRC32 { unzipCRC32 = outputData.crc32(checksum: unzipCRC32) }
             } while stream.avail_out == 0
         } while result != Z_STREAM_END
         return unzipCRC32

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -83,9 +83,10 @@ extension FileManager {
     /// - Parameters:
     ///   - sourceURL: The file URL pointing to an existing ZIP file.
     ///   - destinationURL: The file URL that identifies the destination directory of the unzip operation.
+    ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to speed up performance.
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
-    public func unzipItem(at sourceURL: URL, to destinationURL: URL,
+    public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
                           progress: Progress? = nil, preferredEncoding: String.Encoding? = nil) throws {
         guard self.fileExists(atPath: sourceURL.path) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
@@ -119,9 +120,9 @@ extension FileManager {
             if let progress = progress {
                 let entryProgress = archive.makeProgressForReading(entry)
                 progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
-                _ = try archive.extract(entry, to: destinationEntryURL, progress: entryProgress)
+                _ = try archive.extract(entry, to: destinationEntryURL, skipCRC32: skipCRC32, progress: entryProgress)
             } else {
-                _ = try archive.extract(entry, to: destinationEntryURL)
+                _ = try archive.extract(entry, to: destinationEntryURL, skipCRC32: skipCRC32)
             }
         }
     }


### PR DESCRIPTION
Fixes #120 

# Changes proposed in this PR
* Exposed the `skipCRC32` flag when reading/extracting an archive.

Why? Skipping the CRC calculation results in improved performance for users who are not interested in comparing the CRC. 

# Tests performed
All tests pass.

# Further info for the reviewer
I don't have a development environment set up for Linux, so I could not run the tests there.

# Open Issues
none