### PR TITLE
Update Product Bundle Identifier

### DIFF
--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -211,7 +211,7 @@ extension ZIPFoundationTests {
         guard let entry = Entry(centralDirectoryStructure: cds, localFileHeader: lfh, dataDescriptor: nil) else {
             XCTFail("Failed to create test entry."); return
         }
-        var attributes = FileManager.attributes(from: entry)
+        let attributes = FileManager.attributes(from: entry)
         guard let permissions = attributes[.posixPermissions] as? UInt16 else {
             XCTFail("Failed to read file attributes."); return
         }

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=watchos*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = ZIPFoundation;
+				PRODUCT_BUNDLE_IDENTIFIER = com.peakstep.ZIPFoundation;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -450,7 +450,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=watchos*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = ZIPFoundation;
+				PRODUCT_BUNDLE_IDENTIFIER = com.peakstep.ZIPFoundation;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Fixes #140 

# Changes proposed in this PR
* Prepend a custom string in reverse DNS notation to our existing bundle product ID to fix an error that App Store Connect / Xcode emits when trying to upload an app that consumes ZIP Foundation
