### PR TITLE
fixed error thrown when encountering a broken symlink

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -26,7 +26,7 @@ extension Archive {
         var checksum = CRC32(0)
         switch entry.type {
         case .file:
-            guard !fileManager.fileExists(atPath: url.path) else {
+            guard !FileManager.fileOrSymbolicLinkExists(at: url) else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
             }
             try fileManager.createParentDirectoryStructure(for: url)
@@ -43,7 +43,7 @@ extension Archive {
             }
             checksum = try self.extract(entry, bufferSize: bufferSize, progress: progress, consumer: consumer)
         case .symlink:
-            guard !fileManager.fileExists(atPath: url.path) else {
+            guard !FileManager.fileOrSymbolicLinkExists(at: url) else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
             }
             let consumer = { (data: Data) in

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -30,13 +30,14 @@ extension Archive {
                          bufferSize: UInt32 = defaultWriteChunkSize, progress: Progress? = nil) throws {
         let fileManager = FileManager()
         let entryURL = baseURL.appendingPathComponent(path)
-        guard fileManager.fileExists(atPath: entryURL.path) else {
+        guard FileManager.fileOrSymbolicLinkExists(at: entryURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: entryURL.path])
         }
-        guard fileManager.isReadableFile(atPath: entryURL.path) else {
+        let type = try FileManager.typeForItem(at: entryURL)
+        // symlinks do not need to be readable
+        guard type == .symlink || fileManager.isReadableFile(atPath: entryURL.path) else {
             throw CocoaError(.fileReadNoPermission, userInfo: [NSFilePathErrorKey: url.path])
         }
-        let type = try FileManager.typeForItem(at: entryURL)
         let modDate = try FileManager.fileModificationDateTimeForItem(at: entryURL)
         let uncompressedSize = type == .directory ? 0 : try FileManager.fileSizeForItem(at: entryURL)
         let permissions = try FileManager.permissionsForItem(at: entryURL)

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -141,7 +141,7 @@ public final class Archive: Sequence {
         let fileManager = FileManager()
         switch mode {
         case .read:
-            guard fileManager.fileExists(atPath: url.path) else { return nil }
+            guard FileManager.fileOrSymbolicLinkExists(at: url) else { return nil }
             guard fileManager.isReadableFile(atPath: url.path) else { return nil }
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
             guard let archiveFile = fopen(fileSystemRepresentation, "rb"),
@@ -151,7 +151,7 @@ public final class Archive: Sequence {
             self.archiveFile = archiveFile
             self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
         case .create:
-            guard !fileManager.fileExists(atPath: url.path) else { return nil }
+            guard !FileManager.fileOrSymbolicLinkExists(at: url) else { return nil }
             let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(numberOfDisk: 0, numberOfDiskStart: 0,
                                                                           totalNumberOfEntriesOnDisk: 0,
                                                                           totalNumberOfEntriesInCentralDirectory: 0,

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -112,7 +112,7 @@ extension ZIPFoundationTests {
         var itemsExist = false
         for entry in archive {
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
-            itemsExist = fileManager.fileExists(atPath: directoryURL.path)
+            itemsExist = FileManager.fileOrSymbolicLinkExists(at: directoryURL)
             if !itemsExist { break }
         }
         XCTAssert(itemsExist)

--- a/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
@@ -170,7 +170,7 @@ extension ZIPFoundationTests {
             var itemsExist = false
             for entry in archive {
                 let directoryURL = destinationURL.appendingPathComponent(entry.path)
-                itemsExist = fileManager.fileExists(atPath: directoryURL.path)
+                itemsExist = FileManager.fileOrSymbolicLinkExists(at: directoryURL)
                 if !itemsExist { break }
             }
             XCTAssert(itemsExist)

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -50,7 +50,7 @@ extension ZIPFoundationTests {
                 checksum = try archive.extract(entry, to: fileURL)
                 XCTAssert(entry.checksum == checksum)
                 let fileManager = FileManager()
-                XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
+                XCTAssertTrue(FileManager.fileOrSymbolicLinkExists(at: fileURL))
                 if entry.type != .directory {
                     let fileData = try Data(contentsOf: fileURL)
                     let checksum = fileData.crc32(checksum: 0)

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -44,7 +44,7 @@ class ZIPFoundationTests: XCTestCase {
         super.setUp()
         do {
             let fileManager = FileManager()
-            if fileManager.fileExists(atPath: tempZipDirectoryURL.path) {
+            if FileManager.fileOrSymbolicLinkExists(at: tempZipDirectoryURL) {
                 try fileManager.removeItem(at: tempZipDirectoryURL)
             }
             try fileManager.createDirectory(at: tempZipDirectoryURL,


### PR DESCRIPTION
# Fixes

When encountering a broken symlink, a false positive .fileReadNoSuchFile Error was thrown, because we were using FileManager.fileExists() to check file existence. It's perfectly valid (and in my use case essential) to include a broken symlink into a zip archive.

# Changes proposed in this PR
*  Use Url.checkResourceIsReachable() instead

# Tests performed
Full test suite on macOS Catalina 10.15.1

# Further info for the reviewer

# Open Issues

None reported before AFAIK.
