### PR TITLE
fixed error thrown when encountering a broken symlink

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -162,5 +162,5 @@ jobs:
   steps:
     - script: xcodebuild test -destination 'platform=macOS,arch=x86_64' -scheme "ZIPFoundation" -derivedDataPath Build/ 
       displayName: Generate xccovreport
-    - script: (xcrun xccov view --only-targets Build/Logs/Test/*.xcresult/*_Test/action.xccovreport | grep -Eq  "ZIPFoundation.*100\.00%") && { exit 0; } || { echo '##vso[task.logissue type=error;]Please make sure that the test suite covers all framework code paths.'; exit 1; }
+    - script: (xcrun xccov view --only-targets --report Build/Logs/Test/*.xcresult | grep -Eq  "ZIPFoundation.*100\.00%") && { exit 0; } || { echo '##vso[task.logissue type=error;]Please make sure that the test suite covers all framework code paths.'; exit 1; }
       displayName: Check for full line coverage

--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -35,11 +35,11 @@ jobs:
     - script: swift test -c release -Xswiftc -enable-testing
       displayName: Linux Swift 4.0
 
-- job: macOS_10_13
+- job: macOS_10_14
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     - task: Xcode@5
       inputs:
@@ -61,9 +61,9 @@ jobs:
 
 - job: iOS_12_1
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     - task: Xcode@5
       inputs:
@@ -76,7 +76,7 @@ jobs:
         sdk: 'iphonesimulator'
         destinationPlatformOption: 'iOS'
         destinationTypeOption: 'simulators'
-        destinationSimulators: 'iPhone X'
+        destinationSimulators: 'iPhone 11'
         useXcpretty: true
         publishJUnitResults: true
     - task: PublishTestResults@2
@@ -87,9 +87,9 @@ jobs:
 
 - job: watchOS_5_1
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     # We currently only perform a build-only script for watchOS (xcodebuild test is unable to find the XCTest module)
     - task: Xcode@5
@@ -107,9 +107,9 @@ jobs:
 
 - job: tvOS_12_1
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     - task: Xcode@5
       inputs:
@@ -133,9 +133,9 @@ jobs:
 
 - job: SwiftLint
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     - script: xcodebuild -scheme ZIPFoundation clean build-for-testing > xcodebuild.log
       displayName: Generate xcodebuild.log
@@ -156,9 +156,9 @@ jobs:
 
 - job: CodeCoverage
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_10.1.app
+    DEVELOPER_DIR: /Applications/Xcode_11.2.app
   steps:
     - script: xcodebuild test -destination 'platform=macOS,arch=x86_64' -scheme "ZIPFoundation" -derivedDataPath Build/ 
       displayName: Generate xccovreport

--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -27,7 +27,7 @@ extension Archive {
         var checksum = CRC32(0)
         switch entry.type {
         case .file:
-            guard !FileManager.fileOrSymbolicLinkExists(at: url) else {
+            guard !fileManager.itemExists(at: url) else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
             }
             try fileManager.createParentDirectoryStructure(for: url)
@@ -46,7 +46,7 @@ extension Archive {
             checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                         progress: progress, consumer: consumer)
         case .symlink:
-            guard !FileManager.fileOrSymbolicLinkExists(at: url) else {
+            guard !fileManager.itemExists(at: url) else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
             }
             let consumer = { (data: Data) in

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -30,7 +30,7 @@ extension Archive {
                          bufferSize: UInt32 = defaultWriteChunkSize, progress: Progress? = nil) throws {
         let fileManager = FileManager()
         let entryURL = baseURL.appendingPathComponent(path)
-        guard FileManager.fileOrSymbolicLinkExists(at: entryURL) else {
+        guard fileManager.itemExists(at: entryURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: entryURL.path])
         }
         let type = try FileManager.typeForItem(at: entryURL)

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -231,8 +231,7 @@ extension FileManager {
         return Entry.EntryType(mode: fileStat.st_mode)
     }
 
-    class func fileOrSymbolicLinkExists(at url : URL) -> Bool
-    {
+    class func fileOrSymbolicLinkExists(at url: URL) -> Bool {
         // A broken symlink would throw a .fileReadNoSuchFile false positive
         // Error using a FileManager.fileExists() check, as stated in Apple
         // documentation. Using checkResourceIsReachable() instead

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -31,10 +31,11 @@ extension FileManager {
     public func zipItem(at sourceURL: URL, to destinationURL: URL,
                         shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .none,
                         progress: Progress? = nil) throws {
-        guard FileManager.fileOrSymbolicLinkExists(at: sourceURL) else {
+        let fileManager = FileManager()
+        guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
         }
-        guard !FileManager.fileOrSymbolicLinkExists(at: destinationURL) else {
+        guard !fileManager.itemExists(at: destinationURL) else {
             throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: destinationURL.path])
         }
         guard let archive = Archive(url: destinationURL, accessMode: .create) else {
@@ -88,7 +89,8 @@ extension FileManager {
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
                           progress: Progress? = nil, preferredEncoding: String.Encoding? = nil) throws {
-        guard FileManager.fileOrSymbolicLinkExists(at: sourceURL) else {
+        let fileManager = FileManager()
+        guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
         }
         guard let archive = Archive(url: sourceURL, accessMode: .read, preferredEncoding: preferredEncoding) else {
@@ -128,6 +130,13 @@ extension FileManager {
     }
 
     // MARK: - Helpers
+
+    func itemExists(at url: URL) -> Bool {
+        // A broken symlink would throw a .fileReadNoSuchFile false positive
+        // Error using a FileManager.fileExists() check, as stated in Apple
+        // documentation. Using checkResourceIsReachable() instead
+        return (try? url.checkResourceIsReachable()) == true
+    }
 
     func createParentDirectoryStructure(for url: URL) throws {
         let parentDirectoryURL = url.deletingLastPathComponent()
@@ -192,7 +201,7 @@ extension FileManager {
 
     class func fileModificationDateTimeForItem(at url: URL) throws -> Date {
         let fileManager = FileManager()
-        guard FileManager.fileOrSymbolicLinkExists(at: url) else {
+        guard fileManager.itemExists(at: url) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path])
         }
         let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
@@ -211,7 +220,7 @@ extension FileManager {
 
     class func fileSizeForItem(at url: URL) throws -> UInt32 {
         let fileManager = FileManager()
-        guard FileManager.fileOrSymbolicLinkExists(at: url) else {
+        guard fileManager.itemExists(at: url) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path])
         }
         let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
@@ -221,21 +230,14 @@ extension FileManager {
     }
 
     class func typeForItem(at url: URL) throws -> Entry.EntryType {
-        guard url.isFileURL, fileOrSymbolicLinkExists(at: url) else {
+        let fileManager = FileManager()
+        guard url.isFileURL, fileManager.itemExists(at: url) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path])
         }
-        let fileManager = FileManager()
         let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
         var fileStat = stat()
         lstat(entryFileSystemRepresentation, &fileStat)
         return Entry.EntryType(mode: fileStat.st_mode)
-    }
-
-    class func fileOrSymbolicLinkExists(at url: URL) -> Bool {
-        // A broken symlink would throw a .fileReadNoSuchFile false positive
-        // Error using a FileManager.fileExists() check, as stated in Apple
-        // documentation. Using checkResourceIsReachable() instead
-        return (try? url.checkResourceIsReachable()) == true
     }
 }
 

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -132,9 +132,12 @@ extension FileManager {
     // MARK: - Helpers
 
     func itemExists(at url: URL) -> Bool {
-        // A broken symlink would throw a .fileReadNoSuchFile false positive
-        // Error using a FileManager.fileExists() check, as stated in Apple
-        // documentation. Using checkResourceIsReachable() instead
+        // Use `URL.checkResourceIsReachable()` instead of `FileManager.fileExists()` here
+        // because we don't want implicit symlink resolution.
+        // As per documentation, `FileManager.fileExists()` traverses symlinks and therefore a broken symlink
+        // would throw a `.fileReadNoSuchFile` false positive error.
+        // For ZIP files it may be intended to archive "broken" symlinks because they might be
+        // resolvable again when extracting the archive to a different destination.
         return (try? url.checkResourceIsReachable()) == true
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -112,7 +112,7 @@ extension ZIPFoundationTests {
         var itemsExist = false
         for entry in archive {
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
-            itemsExist = FileManager.fileOrSymbolicLinkExists(at: directoryURL)
+            itemsExist = fileManager.itemExists(at: directoryURL)
             if !itemsExist { break }
         }
         XCTAssert(itemsExist)
@@ -131,7 +131,7 @@ extension ZIPFoundationTests {
         var itemsExist = false
         for entry in archive {
             let directoryURL = destinationURL.appendingPathComponent(entry.path(using: encoding))
-            itemsExist = FileManager.fileOrSymbolicLinkExists(at: directoryURL)
+            itemsExist = fileManager.itemExists(at: directoryURL)
             if !itemsExist { break }
         }
         XCTAssert(itemsExist)

--- a/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
@@ -170,7 +170,7 @@ extension ZIPFoundationTests {
             var itemsExist = false
             for entry in archive {
                 let directoryURL = destinationURL.appendingPathComponent(entry.path)
-                itemsExist = FileManager.fileOrSymbolicLinkExists(at: directoryURL)
+                itemsExist = fileManager.itemExists(at: directoryURL)
                 if !itemsExist { break }
             }
             XCTAssert(itemsExist)

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -25,7 +25,7 @@ extension ZIPFoundationTests {
                 checksum = try archive.extract(entry, to: fileURL)
                 XCTAssert(entry.checksum == checksum)
                 let fileManager = FileManager()
-                XCTAssertTrue(FileManager.fileOrSymbolicLinkExists(at: fileURL))
+                XCTAssertTrue(fileManager.itemExists(at: fileURL))
                 if entry.type == .file {
                     let fileData = try Data(contentsOf: fileURL)
                     let checksum = fileData.crc32(checksum: 0)
@@ -50,7 +50,7 @@ extension ZIPFoundationTests {
                 checksum = try archive.extract(entry, to: fileURL)
                 XCTAssert(entry.checksum == checksum)
                 let fileManager = FileManager()
-                XCTAssertTrue(FileManager.fileOrSymbolicLinkExists(at: fileURL))
+                XCTAssertTrue(fileManager.itemExists(at: fileURL))
                 if entry.type != .directory {
                     let fileData = try Data(contentsOf: fileURL)
                     let checksum = fileData.crc32(checksum: 0)

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -44,7 +44,7 @@ class ZIPFoundationTests: XCTestCase {
         super.setUp()
         do {
             let fileManager = FileManager()
-            if FileManager.fileOrSymbolicLinkExists(at: tempZipDirectoryURL) {
+            if fileManager.itemExists(at: tempZipDirectoryURL) {
                 try fileManager.removeItem(at: tempZipDirectoryURL)
             }
             try fileManager.createDirectory(at: tempZipDirectoryURL,


### PR DESCRIPTION
# Fixes

When encountering a broken symlink, a false positive .fileReadNoSuchFile Error was thrown, because we were using FileManager.fileExists() to check file existence. It's perfectly valid (and in my use case essential) to include a broken symlink into a zip archive.

# Changes proposed in this PR
*  Use Url.checkResourceIsReachable() instead

# Tests performed
Full test suite on macOS Catalina 10.15.1

# Further info for the reviewer

# Open Issues

None reported before AFAIK.
