### PR TITLE
Memory safety fix

### DIFF
--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -260,9 +260,8 @@ extension Data {
                         stream.next_out = pointer
                         result = deflate(&stream, flush)
                     }
-                    guard result >= Z_OK  else {
-                        throw CompressionError.corruptedData
-                    }
+                    guard result >= Z_OK else { throw CompressionError.corruptedData }
+
                     outputChunk.count = bufferSize - Int(stream.avail_out)
                     try consumer(outputChunk)
                 } while stream.avail_out == 0

--- a/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
@@ -61,7 +61,7 @@ extension ZIPFoundationTests {
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
         let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb")
-        // Close the file to exercice the error path during writeChunk that deals with
+        // Close the file to exercise the error path during writeChunk that deals with
         // unwritable files.
         fclose(file)
         do {

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -215,7 +215,7 @@ extension ZIPFoundationTests {
         do {
             try archive.addEntry(with: fileName, type: .file, uncompressedSize: UINT32_MAX,
                                  provider: { (_, chunkSize) -> Data in
-                return Data.makeRandomData(size: chunkSize)
+                return Data(count: chunkSize)
             })
         } catch let error as Archive.ArchiveError {
             XCTAssertNotNil(error == .invalidStartOfCentralDirectoryOffset)


### PR DESCRIPTION
Fixes #155

# Changes proposed in this PR 
In the Linux compression path, the code in a few places used a raw pointer obtained by `withUnsafeMutableByes` *outside* of the closure argument passed to that function. This is not a correct use of that API, and in fact, I've observed in some situation that compression failed because the data pointed to changed between the call to `withUnsafeMutableBytes` and the use.

The fix is simply to nest the code using the data inside the closure argument. This looks a bit uglier due to the deeper nesting, but no longer exhibits the problems I saw earlier.

# Tests performed
Ran unit tests, and used the modified code in my app.
