### PR TITLE
Path Encoding

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -231,17 +231,15 @@ extension Archive {
                                       size: (uncompressed: UInt32, compressed: UInt32),
                                       checksum: CRC32,
                                       modificationDateTime: (UInt16, UInt16)) throws -> LocalFileHeader {
-        let fileManager = FileManager()
-        let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: path)
-        let fileNameLength = Int(strlen(fileSystemRepresentation))
-        let fileNameBuffer = UnsafeBufferPointer(start: fileSystemRepresentation, count: fileNameLength)
-        let fileNameData = Data(buffer: fileNameBuffer)
+        // We always set Bit 11 in generalPurposeBitFlag, which indicates an UTF-8 encoded path.
+        guard let fileNameData = path.data(using: .utf8) else { throw ArchiveError.invalidEntryPath }
+
         let localFileHeader = LocalFileHeader(versionNeededToExtract: UInt16(20), generalPurposeBitFlag: UInt16(2048),
                                               compressionMethod: compressionMethod.rawValue,
                                               lastModFileTime: modificationDateTime.1,
                                               lastModFileDate: modificationDateTime.0, crc32: checksum,
                                               compressedSize: size.compressed, uncompressedSize: size.uncompressed,
-                                              fileNameLength: UInt16(fileNameLength), extraFieldLength: UInt16(0),
+                                              fileNameLength: UInt16(fileNameData.count), extraFieldLength: UInt16(0),
                                               fileNameData: fileNameData, extraFieldData: Data())
         _ = try Data.write(chunk: localFileHeader.data, to: self.archiveFile)
         return localFileHeader

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -127,6 +127,8 @@ public final class Archive: Sequence {
     ///   - url: File URL to the receivers backing file.
     ///   - mode: Access mode of the receiver.
     ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///                        This encoding is only used when _decoding_ paths from the receiver.
+    ///                        Paths of entries added with `addEntry` are always UTF-8 encoded.
     /// - Returns: An archive initialized with a backing file at the passed in file URL and the given access mode
     ///   or `nil` if the following criteria are not met:
     /// - Note:
@@ -156,7 +158,8 @@ public final class Archive: Sequence {
     ///   - data: `Data` object used as backing for in-memory archives.
     ///   - mode: Access mode of the receiver.
     ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
-    ///
+    ///                        This encoding is only used when _decoding_ paths from the receiver.
+    ///                        Paths of entries added with `addEntry` are always UTF-8 encoded.
     /// - Returns: An in-memory archive initialized with passed in backing data.
     /// - Note:
     ///   - The backing `data` _must_ contain a valid ZIP archive for `AccessMode.read` and `AccessMode.update`.

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -117,12 +117,7 @@ public final class Archive: Sequence {
     /// Initializes a new ZIP `Archive`.
     ///
     /// You can use this initalizer to create new archive files or to read and update existing ones.
-    ///
-    /// To read existing ZIP files, pass in an existing file URL and `AccessMode.read`.
-    ///
-    /// To create a new ZIP file, pass in a non-existing file URL and `AccessMode.create`.
-    ///
-    /// To update an existing ZIP file, pass in an existing file URL and `AccessMode.update`.
+    /// The `mode` parameter indicates the intended usage of the archive: `.read`, `.create` or `.update`.
     /// - Parameters:
     ///   - url: File URL to the receivers backing file.
     ///   - mode: Access mode of the receiver.

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -93,8 +93,9 @@ public struct Entry: Equatable {
         let extraFieldData: Data
         let fileCommentData: Data
         var usesDataDescriptor: Bool { return (self.generalPurposeBitFlag & (1 << 3 )) != 0 }
-        var isZIP64: Bool { return self.versionNeededToExtract >= 45 }
+        var usesUTF8PathEncoding: Bool { return (self.generalPurposeBitFlag & (1 << 11 )) != 0 }
         var isEncrypted: Bool { return (self.generalPurposeBitFlag & (1 << 0)) != 0 }
+        var isZIP64: Bool { return self.versionNeededToExtract >= 45 }
     }
     /// Returns the `path` of the receiver within a ZIP `Archive` using a given encoding.
     ///
@@ -109,8 +110,7 @@ public struct Entry: Equatable {
         let dosLatinUSEncoding = CFStringEncoding(dosLatinUS)
         let dosLatinUSStringEncoding = CFStringConvertEncodingToNSStringEncoding(dosLatinUSEncoding)
         let codepage437 = String.Encoding(rawValue: dosLatinUSStringEncoding)
-        let isUTF8 = ((self.centralDirectoryStructure.generalPurposeBitFlag >> 11) & 1) != 0
-        let encoding = isUTF8 ? String.Encoding.utf8 : codepage437
+        let encoding = self.centralDirectoryStructure.usesUTF8PathEncoding ? .utf8 : codepage437
         return self.path(using: encoding)
     }
     /// The file attributes of the receiver as key/value pairs.

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -87,6 +87,7 @@ extension FileManager {
     ///   - destinationURL: The file URL that identifies the destination directory of the unzip operation.
     ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
+    ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
                           progress: Progress? = nil, preferredEncoding: String.Encoding? = nil) throws {


### PR DESCRIPTION
Fixes #63 

# Changes proposed in this PR
* Improves documentation for `preferredEncoding`
* Ensures that paths are encoded as UTF-8 during entry addition