### PR TITLE
Dangling Buffer Pointer Warnings

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -345,22 +345,23 @@ extension Archive {
 
 extension Archive.EndOfCentralDirectoryRecord {
     var data: Data {
-        var endOfCentralDirectorySignature = self.endOfCentralDirectorySignature
+        var endOfCDSignature = self.endOfCentralDirectorySignature
         var numberOfDisk = self.numberOfDisk
         var numberOfDiskStart = self.numberOfDiskStart
         var totalNumberOfEntriesOnDisk = self.totalNumberOfEntriesOnDisk
-        var totalNumberOfEntriesInCentralDirectory = self.totalNumberOfEntriesInCentralDirectory
+        var totalNumberOfEntriesInCD = self.totalNumberOfEntriesInCentralDirectory
         var sizeOfCentralDirectory = self.sizeOfCentralDirectory
-        var offsetToStartOfCentralDirectory = self.offsetToStartOfCentralDirectory
+        var offsetToStartOfCD = self.offsetToStartOfCentralDirectory
         var zipFileCommentLength = self.zipFileCommentLength
-        var data = Data(buffer: UnsafeBufferPointer(start: &endOfCentralDirectorySignature, count: 1))
-        data.append(UnsafeBufferPointer(start: &numberOfDisk, count: 1))
-        data.append(UnsafeBufferPointer(start: &numberOfDiskStart, count: 1))
-        data.append(UnsafeBufferPointer(start: &totalNumberOfEntriesOnDisk, count: 1))
-        data.append(UnsafeBufferPointer(start: &totalNumberOfEntriesInCentralDirectory, count: 1))
-        data.append(UnsafeBufferPointer(start: &sizeOfCentralDirectory, count: 1))
-        data.append(UnsafeBufferPointer(start: &offsetToStartOfCentralDirectory, count: 1))
-        data.append(UnsafeBufferPointer(start: &zipFileCommentLength, count: 1))
+        var data = Data()
+        withUnsafePointer(to: &endOfCDSignature, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &numberOfDisk, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &numberOfDiskStart, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &totalNumberOfEntriesOnDisk, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &totalNumberOfEntriesInCD, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &sizeOfCentralDirectory, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &offsetToStartOfCD, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &zipFileCommentLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
         data.append(self.zipFileCommentData)
         return data
     }

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -278,23 +278,24 @@ extension Entry.CentralDirectoryStructure {
         var internalFileAttributes = self.internalFileAttributes
         var externalFileAttributes = self.externalFileAttributes
         var relativeOffsetOfLocalHeader = self.relativeOffsetOfLocalHeader
-        var data = Data(buffer: UnsafeBufferPointer(start: &centralDirectorySignature, count: 1))
-        data.append(UnsafeBufferPointer(start: &versionMadeBy, count: 1))
-        data.append(UnsafeBufferPointer(start: &versionNeededToExtract, count: 1))
-        data.append(UnsafeBufferPointer(start: &generalPurposeBitFlag, count: 1))
-        data.append(UnsafeBufferPointer(start: &compressionMethod, count: 1))
-        data.append(UnsafeBufferPointer(start: &lastModFileTime, count: 1))
-        data.append(UnsafeBufferPointer(start: &lastModFileDate, count: 1))
-        data.append(UnsafeBufferPointer(start: &crc32, count: 1))
-        data.append(UnsafeBufferPointer(start: &compressedSize, count: 1))
-        data.append(UnsafeBufferPointer(start: &uncompressedSize, count: 1))
-        data.append(UnsafeBufferPointer(start: &fileNameLength, count: 1))
-        data.append(UnsafeBufferPointer(start: &extraFieldLength, count: 1))
-        data.append(UnsafeBufferPointer(start: &fileCommentLength, count: 1))
-        data.append(UnsafeBufferPointer(start: &diskNumberStart, count: 1))
-        data.append(UnsafeBufferPointer(start: &internalFileAttributes, count: 1))
-        data.append(UnsafeBufferPointer(start: &externalFileAttributes, count: 1))
-        data.append(UnsafeBufferPointer(start: &relativeOffsetOfLocalHeader, count: 1))
+        var data = Data()
+        withUnsafePointer(to: &centralDirectorySignature, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &versionMadeBy, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &versionNeededToExtract, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &generalPurposeBitFlag, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &compressionMethod, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &lastModFileTime, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &lastModFileDate, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &crc32, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &compressedSize, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &uncompressedSize, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &fileNameLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &extraFieldLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &fileCommentLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &diskNumberStart, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &internalFileAttributes, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &externalFileAttributes, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &relativeOffsetOfLocalHeader, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
         data.append(self.fileNameData)
         data.append(self.extraFieldData)
         data.append(self.fileCommentData)
@@ -384,8 +385,7 @@ extension Entry.DataDescriptor {
     init?(data: Data, additionalDataProvider provider: (Int) throws -> Data) {
         guard data.count == Entry.DataDescriptor.size else { return nil }
         let signature: UInt32 = data.scanValue(start: 0)
-        // The DataDescriptor signature is not mandatory so we have to re-arrange
-        // the input data if it is missing
+        // The DataDescriptor signature is not mandatory so we have to re-arrange the input data if it is missing.
         var readOffset = 0
         if signature == self.dataDescriptorSignature { readOffset = 4 }
         self.crc32 = data.scanValue(start: readOffset + 0)

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -151,8 +151,7 @@ public struct Entry: Equatable {
             }
         case .msdos:
             isDirectory = isDirectory || ((centralDirectoryStructure.externalFileAttributes >> 4) == 0x01)
-            fallthrough
-        // For all other OSes we can only guess based on the directory suffix char
+            fallthrough // For all other OSes we can only guess based on the directory suffix char
         default: return isDirectory ? .directory : .file
         }
     }
@@ -218,17 +217,18 @@ extension Entry.LocalFileHeader {
         var uncompressedSize = self.uncompressedSize
         var fileNameLength = self.fileNameLength
         var extraFieldLength = self.extraFieldLength
-        var data = Data(buffer: UnsafeBufferPointer(start: &localFileHeaderSignature, count: 1))
-        data.append(UnsafeBufferPointer(start: &versionNeededToExtract, count: 1))
-        data.append(UnsafeBufferPointer(start: &generalPurposeBitFlag, count: 1))
-        data.append(UnsafeBufferPointer(start: &compressionMethod, count: 1))
-        data.append(UnsafeBufferPointer(start: &lastModFileTime, count: 1))
-        data.append(UnsafeBufferPointer(start: &lastModFileDate, count: 1))
-        data.append(UnsafeBufferPointer(start: &crc32, count: 1))
-        data.append(UnsafeBufferPointer(start: &compressedSize, count: 1))
-        data.append(UnsafeBufferPointer(start: &uncompressedSize, count: 1))
-        data.append(UnsafeBufferPointer(start: &fileNameLength, count: 1))
-        data.append(UnsafeBufferPointer(start: &extraFieldLength, count: 1))
+        var data = Data()
+        withUnsafePointer(to: &localFileHeaderSignature, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &versionNeededToExtract, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &generalPurposeBitFlag, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &compressionMethod, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &lastModFileTime, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &lastModFileDate, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &crc32, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &compressedSize, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &uncompressedSize, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &fileNameLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
+        withUnsafePointer(to: &extraFieldLength, { data.append(UnsafeBufferPointer(start: $0, count: 1))})
         data.append(self.fileNameData)
         data.append(self.extraFieldData)
         return data


### PR DESCRIPTION
Fixes #158

# Changes proposed in this PR
* Wrap `UnsafeBufferPointer` usage in `withUnsafePointer` to guarantee valid pointers when appending to `data`
