### PR TITLE
Convert 'Provider' to a protocol

### DIFF
--- a/Tests/ZIPFoundationTests/ZIPFoundationPerformanceTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationPerformanceTests.swift
@@ -20,13 +20,8 @@ extension ZIPFoundationTests {
         measure {
             do {
                 try archive.addEntry(with: entryName, type: .file,
-                                     uncompressedSize: UInt32(size),
                                      compressionMethod: .none,
-                                     provider: { (position, bufferSize) -> Data in
-                                        let upperBound = Swift.min(size, position + bufferSize)
-                                        let range = Range(uncheckedBounds: (lower: position, upper: upperBound))
-                                        return data.subdata(in: range)
-                })
+                                     provider: data)
             } catch {
                 XCTFail("Failed to add large entry to uncompressed archive with error : \(error)")
             }
@@ -40,13 +35,8 @@ extension ZIPFoundationTests {
         let entryName = ProcessInfo.processInfo.globallyUniqueString
         do {
             try archive.addEntry(with: entryName, type: .file,
-                                 uncompressedSize: UInt32(size),
                                  compressionMethod: .none,
-                                 provider: { (position, bufferSize) -> Data in
-                                    let upperBound = Swift.min(size, position + bufferSize)
-                                    let range = Range(uncheckedBounds: (lower: position, upper: upperBound))
-                                    return data.subdata(in: range)
-            })
+                                 provider: data)
         } catch {
             XCTFail("Failed to add large entry to uncompressed archive with error : \(error)")
         }
@@ -71,13 +61,8 @@ extension ZIPFoundationTests {
         measure {
             do {
                 try archive.addEntry(with: entryName, type: .file,
-                                     uncompressedSize: UInt32(size),
                                      compressionMethod: .deflate,
-                                     provider: { (position, bufferSize) -> Data in
-                                        let upperBound = Swift.min(size, position + bufferSize)
-                                        let range = Range(uncheckedBounds: (lower: position, upper: upperBound))
-                                        return data.subdata(in: range)
-                })
+                                     provider: data)
             } catch {
                 XCTFail("Failed to add large entry to compressed archive with error : \(error)")
             }
@@ -91,13 +76,8 @@ extension ZIPFoundationTests {
         let entryName = ProcessInfo.processInfo.globallyUniqueString
         do {
             try archive.addEntry(with: entryName, type: .file,
-                                 uncompressedSize: UInt32(size),
                                  compressionMethod: .deflate,
-                                 provider: { (position, bufferSize) -> Data in
-                                    let upperBound = Swift.min(size, position + bufferSize)
-                                    let range = Range(uncheckedBounds: (lower: position, upper: upperBound))
-                                    return data.subdata(in: range)
-            })
+                                 provider: data)
         } catch {
             XCTFail("Failed to add large entry to compressed archive with error : \(error)")
         }


### PR DESCRIPTION
This allows passing in a Data or UnsafeBufferPointer into addEntry, without having to specify your own Provider function.

# Changes proposed in this PR

* Converting Provider to a Protocol

# Tests performed

I added a test that uses a UnsafeBufferPointer from a String, showing that this is now super easy.

# Further info for the reviewer

This is obviously backwards-compatibility breaking. What we could do is add additional overrides for addEntry that take in a protocol, and keep the old ones with uncompressedSize and the Provider function. Then we could write a wrapper that takes those two values and creates a protocol implementation out of it.

# Open Issues

There's probably some style issues, but I've never used swiftlint before so I don't know how to get it to format my code properly. I'll have to look into that. First I'd like just some feedback on what you think of this change and whether you find it worthwhile. I think it will make the project a lot more ergonomic to use, I think it immediately improves the internal code too.

- [ ] Fix linux code (haven't looked at it yet)