### PR TITLE
Fixing trailing slash in Swift Package Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import PackageDescription
 let package = Package(
     name: "<Your Product Name>",
     dependencies: [
-		.package(url: "https://github.com/weichsel/ZIPFoundation/", .upToNextMajor(from: "0.9.0"))
+		.package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Changes proposed in this PR
* Using a trailing slash causes issues on some CI systems (i.e. Circle-CI), therefore I've made a change to documentation for this.
