### PR TITLE
Avoid integer overflows when calculation additional data length

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -198,7 +198,7 @@ public final class Archive: Sequence {
                                                                          at: offset) else { return nil }
             var dataDescriptor: DataDescriptor?
             if centralDirStruct.usesDataDescriptor {
-                let additionalSize = Int(localFileHeader.fileNameLength + localFileHeader.extraFieldLength)
+                let additionalSize = Int(localFileHeader.fileNameLength) + Int(localFileHeader.extraFieldLength)
                 let isCompressed = centralDirStruct.compressionMethod != CompressionMethod.none.rawValue
                 let dataSize = isCompressed ? centralDirStruct.compressedSize : centralDirStruct.uncompressedSize
                 let descriptorPosition = offset + LocalFileHeader.size + additionalSize + Int(dataSize)

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -247,7 +247,7 @@ extension Entry.LocalFileHeader {
         self.uncompressedSize = data.scanValue(start: 22)
         self.fileNameLength = data.scanValue(start: 26)
         self.extraFieldLength = data.scanValue(start: 28)
-        let additionalDataLength = Int(self.fileNameLength + self.extraFieldLength)
+        let additionalDataLength = Int(self.fileNameLength) + Int(self.extraFieldLength)
         guard let additionalData = try? provider(additionalDataLength) else { return nil }
         guard additionalData.count == additionalDataLength else { return nil }
         var subRangeStart = 0
@@ -321,7 +321,7 @@ extension Entry.CentralDirectoryStructure {
         self.internalFileAttributes = data.scanValue(start: 36)
         self.externalFileAttributes = data.scanValue(start: 38)
         self.relativeOffsetOfLocalHeader = data.scanValue(start: 42)
-        let additionalDataLength = Int(self.fileNameLength + self.extraFieldLength + self.fileCommentLength)
+        let additionalDataLength = Int(self.fileNameLength) + Int(self.extraFieldLength) + Int(self.fileCommentLength)
         guard let additionalData = try? provider(additionalDataLength) else { return nil }
         guard additionalData.count == additionalDataLength else { return nil }
         var subRangeStart = 0


### PR DESCRIPTION
Fixes #179

# Changes proposed in this PR
We used the wrong cast order during calculation of the additional data length. This could potentially lead to an overflow when adding up extra data length fields.
