### PR TITLE
Use `first(where: )` instead of `filter` when subscripting

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -226,9 +226,9 @@ public final class Archive: Sequence {
     /// - Returns: An `Entry` with the given `path`. Otherwise, `nil`.
     public subscript(path: String) -> Entry? {
         if let encoding = preferredEncoding {
-            return self.filter { $0.path(using: encoding) == path }.first
+            return self.first { $0.path(using: encoding) == path }
         }
-        return self.filter { $0.path == path }.first
+        return self.first { $0.path == path }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Fixes #181

# Changes proposed in this PR
* Small code refinement that should speed up subscripting via `path`
