### PR TITLE
Fix potential UInt16 overflow

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -326,8 +326,8 @@ extension Archive {
         var record = self.endOfCentralDirectoryRecord
         let countChange = operation.rawValue
         var dataLength = Int(centralDirectoryStructure.extraFieldLength)
-        dataLength += centralDirectoryStructure.fileNameLength
-        dataLength += centralDirectoryStructure.fileCommentLength
+        dataLength += Int(centralDirectoryStructure.fileNameLength)
+        dataLength += Int(centralDirectoryStructure.fileCommentLength)
         let centralDirectoryDataLengthChange = operation.rawValue * (dataLength + CentralDirectoryStructure.size)
         var updatedSizeOfCentralDirectory = Int(record.sizeOfCentralDirectory)
         updatedSizeOfCentralDirectory += centralDirectoryDataLengthChange

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -325,10 +325,10 @@ extension Archive {
                                             operation: ModifyOperation) throws -> EndOfCentralDirectoryRecord {
         var record = self.endOfCentralDirectoryRecord
         let countChange = operation.rawValue
-        var dataLength = centralDirectoryStructure.extraFieldLength
+        var dataLength = Int(centralDirectoryStructure.extraFieldLength)
         dataLength += centralDirectoryStructure.fileNameLength
         dataLength += centralDirectoryStructure.fileCommentLength
-        let centralDirectoryDataLengthChange = operation.rawValue * (Int(dataLength) + CentralDirectoryStructure.size)
+        let centralDirectoryDataLengthChange = operation.rawValue * (dataLength + CentralDirectoryStructure.size)
         var updatedSizeOfCentralDirectory = Int(record.sizeOfCentralDirectory)
         updatedSizeOfCentralDirectory += centralDirectoryDataLengthChange
         let numberOfEntriesOnDisk = UInt16(Int(record.totalNumberOfEntriesOnDisk) + countChange)


### PR DESCRIPTION
# Changes proposed in this PR
* Fix potential UInt16 overflow.

# Further info for the reviewer
Related: https://github.com/weichsel/ZIPFoundation/pull/180

Maybe unrelated but some users are crashing in writeEndOfCentralDirectory with the following log:
```
0   XXXX                                0x0000000107cdbf08 ZIPFoundation.Archive.(writeEndOfCentralDirectory in _604C70144D53B6896EE0A47AB80823C8)(centralDirectoryStructure: ZIPFoundation.Entry.CentralDirectoryStructure, startOfCentralDirectory: Swift.UInt32, operation: ZIPFoundation.Archive.(ModifyOperation in _604C70144D53B6896EE0A47AB80823C8)) throws -> ZIPFoundation.Archive.EndOfCentralDirectoryRecord (in XXXX) (<compiler-generated>:0)
```
(I could not reproduce the crash.)
