### PR TITLE
Ignore 'deflate' compression on directories and symlinks

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -139,8 +139,6 @@ jobs:
   steps:
     - script: xcodebuild -scheme ZIPFoundation clean build-for-testing > xcodebuild.log
       displayName: Generate xcodebuild.log
-    - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb
-      displayName: Install SwiftLint
     - script: |
         set -o pipefail
         mkdir -p build/reports/

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -98,6 +98,8 @@ extension Archive {
                          compressionMethod: CompressionMethod = .none, bufferSize: UInt32 = defaultWriteChunkSize,
                          progress: Progress? = nil, provider: Provider) throws {
         guard self.accessMode != .read else { throw ArchiveError.unwritableArchive }
+        // Directories and symlinks cannot be compressed
+        let compressionMethod = type == .file ? compressionMethod : .none
         progress?.totalUnitCount = type == .directory ? defaultDirectoryUnitCount : Int64(uncompressedSize)
         var endOfCentralDirRecord = self.endOfCentralDirectoryRecord
         var startOfCD = Int(endOfCentralDirRecord.offsetToStartOfCentralDirectory)

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -103,10 +103,9 @@ extension Archive {
         progress?.totalUnitCount = type == .directory ? defaultDirectoryUnitCount : Int64(uncompressedSize)
         var endOfCentralDirRecord = self.endOfCentralDirectoryRecord
         var startOfCD = Int(endOfCentralDirRecord.offsetToStartOfCentralDirectory)
-        var existingCentralDirData = Data()
         fseek(self.archiveFile, startOfCD, SEEK_SET)
-        existingCentralDirData = try Data.readChunk(of: Int(endOfCentralDirRecord.sizeOfCentralDirectory),
-                                                    from: self.archiveFile)
+        let existingCentralDirData = try Data.readChunk(of: Int(endOfCentralDirRecord.sizeOfCentralDirectory),
+                                                        from: self.archiveFile)
         fseek(self.archiveFile, startOfCD, SEEK_SET)
         let localFileHeaderStart = ftell(self.archiveFile)
         let modDateTime = modificationDate.fileModificationDateTime


### PR DESCRIPTION
# Changes proposed in this PR
* Do not allow "deflate" compression to be used on Directories and Symlinks headers, as this makes an invalid ZIP file

# Tests performed
* Zipped a directory with symlinks
* Tried to "unzip" it from CLI/Finder
* Failed

# Further info for the reviewer
I didn't add an unit test as I don't really know where to begin

# Open Issues
None

---------
Hi,

Thanks for your work! I'm using this library to ZIP a macOS framework.
I'm manually using the "Archive" APIs to do so.
Everything works fine with CompressionMode.none but once I try to use .delfate, it breaks.

I'm basically doing it like this:

```
                        // Add the entry. Do that even if it is a folder, so that an empty folder correctly gets added
                        try archive.addEntry(with: itemName, relativeTo: basePath, compressionMethod: compressionMethod)
                        if isDirectory.boolValue {
                            try recursivelyAddDirectory(archive: archive,
                                                        pathURL: itemURL,
                                                        relativeTo: basePath,
                                                        compressionMethod: compressionMethod)
                        }
                    }

...
            
            /// Recursively zip a directory.
            /// This only supports relatively adding the directory to the root of the zip
            private func recursivelyAddDirectory(archive: ZIPFoundation.Archive,
                                                 pathURL: URL,
                                                 relativeTo basePath: URL,
                                                 compressionMethod: ZIPFoundation.CompressionMethod) throws {
                let subpaths = try fileManager.subpathsOfDirectory(atPath: pathURL.path)
                let directoryName = pathURL.lastPathComponent
                try subpaths.forEach { subpath in
                    try archive.addEntry(with: directoryName + "/" + subpath, relativeTo: basePath, compressionMethod: compressionMethod)
                }
            }
```

Unfortunately, this makes the zip unreadable:
```
 /t/foo2 ➜ unzip -t invalid.zip
Archive:  invalid.zip
    testing: README.md                OK
    testing: LICENSE                  OK
    testing: CHANGELOG.md             OK
    testing: Test.xcframework/      
  error:  invalid compressed data to inflate
    testing: Test.xcframework/ios-x86_64-maccatalyst/Test.framework/Versions/Current
  error:  invalid compressed data to inflate
```

After zipping a file using Finder and checking with zipinfo, I see the following:
```
 /t/foo2 ➜ zipinfo valid2.zip
Archive:  valid2.zip
Zip file size: 17952109 bytes, number of entries: 74
drwxr-xr-x  2.0 unx        0 bx stor 20-Sep-22 17:51 Test.xcframework/
drwxr-xr-x  2.0 unx        0 bx stor 20-Sep-22 17:51 Test.xcframework/ios-x86_64-maccatalyst/
-rw-r--r--  2.0 unx     1508 bX defN 20-Sep-22 17:51 Test.xcframework/Info.plist
lrwxr-xr-x  2.0 unx        1 bx stor 20-Sep-22 17:51 Test.xcframework/ios-x86_64-maccatalyst/Test.framework/Versions/Current
-rw-r--r--  2.0 unx    19514 bX defN 20-Sep-22 17:49 CHANGELOG.md
-rw-r--r--  2.0 unx     1139 bX defN 20-Sep-22 17:49 LICENSE
-rw-r--r--  2.0 unx     1466 bX defN 20-Sep-22 17:49 README.md
```

Whereas my zip looks like this:
```
 /t/foo2 ➜ zipinfo invalid.zip 
Archive:  invalid.zip
Zip file size: 18070482 bytes, number of entries: 74
-rw-r--r--  2.1 unx     1466 b- defN 20-Sep-22 15:49 README.md
-rw-r--r--  2.1 unx     1139 b- defN 20-Sep-22 15:49 LICENSE
-rw-r--r--  2.1 unx    19514 b- defN 20-Sep-22 15:49 CHANGELOG.md
drwxr-xr-x  2.1 unx        0 b- defN 20-Sep-22 15:51 Test.xcframework/
drwxr-xr-x  2.1 unx        0 b- defN 20-Sep-22 15:51 Test.xcframework/ios-x86_64-maccatalyst/
lrwxr-xr-x  2.1 unx        1 b- defN 20-Sep-22 15:51 Test.xcframework/ios-x86_64-maccatalyst/Test.framework/Versions/Current
-rw-r--r--  2.1 unx     1508 b- defN 20-Sep-22 15:51 Test.xcframework/Info.plist
```
Which pointed me in the direction of directories/symlinks being incorrectly written as deflated.

I could fix my code to only use .deflate on files (I have not tested the FileManager zip helper, maybe it works), but I believe that the library should take care of this and save my from shooting myself in the foot.

The patch does exactly that!

Have a nice day,