### PR TITLE
Sort symlinks in order required for unzip

### DIFF
--- a/Sources/ZIPFoundation/Archive+sortEntries.swift
+++ b/Sources/ZIPFoundation/Archive+sortEntries.swift
@@ -1,0 +1,76 @@
+extension Archive {
+    /// Sorts and returns the provided entries in to the order they should be extract in. This will
+    /// sort directories first, then files, then symlinks.
+    ///
+    /// Directories and files are sorted in the order they are in the archive. Symlinks will be
+    /// sorted in the order they need to be extracted.
+    ///
+    /// - Parameters:
+    ///   - entries: The entries to sort
+    /// - Returns: The sorted entries.
+    /// - Throws: An error if the entry contains malformed content.
+    public func sortEntries(_ entries: [Entry]) throws -> [Entry] {
+        let sortedSymlinks = try sortSymblinks(in: entries)
+        let sortedFilesAndDirectories = sortFilesAndDirectories(in: entries)
+        return sortedFilesAndDirectories + sortedSymlinks
+    }
+
+    private func sortSymblinks(in entries: [Entry]) throws -> [Entry] {
+        return try entries
+            .lazy
+            .filter { entry in
+                entry.type == .symlink
+            }.map { entry -> (entry: Entry, destination: String) in
+                var destinationPath: String!
+                _ = try extract(entry, bufferSize: defaultReadChunkSize, skipCRC32: true) { data in
+                    guard let linkPath = String(data: data, encoding: .utf8) else {
+                        throw ArchiveError.invalidEntryPath
+                    }
+                    destinationPath = entry
+                        .path
+                        .split(separator: "/")
+                        .dropLast()
+                        .joined(separator: "/")
+                        + "/"
+                        + linkPath
+                }
+                return (entry, destinationPath)
+            }.reduce(into: [(entry: Entry, destination: String)]()) { entries, element in
+                let unsortedPath = element.entry.path
+                let unsortedDestination = element.destination
+
+                for (index, sortedElement) in entries.enumerated() {
+                    let sortedPath = sortedElement.entry.path
+                    let sortedDestination = sortedElement.destination
+
+                    if unsortedDestination.hasPrefix(sortedDestination) {
+                        entries.insert(element, at: entries.index(after: index))
+                        return
+                    } else if sortedDestination.hasPrefix(unsortedDestination) {
+                        entries.insert(element, at: index)
+                        return
+                    } else if sortedDestination.hasPrefix(unsortedPath) {
+                        entries.insert(element, at: index)
+                        return
+                    } else if unsortedDestination.hasPrefix(sortedPath) {
+                        entries.insert(element, at: entries.index(after: index))
+                        return
+                    }
+                }
+
+                entries.append(element)
+            }.map { $0.entry }
+    }
+
+    private func sortFilesAndDirectories(in entries: [Entry]) -> [Entry] {
+        return entries
+            .filter { entry in
+                entry.type != .symlink
+            }.sorted { (left, right) -> Bool in
+                switch (left.type, right.type) {
+                case (.file, .directory): return false
+                default: return true
+                }
+            }
+    }
+}

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -98,16 +98,7 @@ extension FileManager {
         guard let archive = Archive(url: sourceURL, accessMode: .read, preferredEncoding: preferredEncoding) else {
             throw Archive.ArchiveError.unreadableArchive
         }
-        // Defer extraction of symlinks until all files & directories have been created.
-        // This is necessary because we can't create links to files that haven't been created yet.
-        let sortedEntries = archive.sorted { (left, right) -> Bool in
-            switch (left.type, right.type) {
-            case (.directory, .file): return true
-            case (.directory, .symlink): return true
-            case (.file, .symlink): return true
-            default: return false
-            }
-        }
+        let sortedEntries = try archive.sortEntries(Array(archive.makeIterator()))
         var totalUnitCount = Int64(0)
         if let progress = progress {
             totalUnitCount = sortedEntries.reduce(0, { $0 + archive.totalUnitCountForReading($1) })

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		95B5A3D42366731B00D4D8FD /* Archive+MemoryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B5A3D32366731B00D4D8FD /* Archive+MemoryFile.swift */; };
 		95B5A3D72367999900D4D8FD /* ZIPFoundationMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B5A3D52367983A00D4D8FD /* ZIPFoundationMemoryTests.swift */; };
 		BA3716AB21F0A238006E54E6 /* ZIPFoundationProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3716A921F0A1AC006E54E6 /* ZIPFoundationProgressTests.swift */; };
+		D9C5971D251CBC50000AF11F /* Archive+sortEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C5971C251CBC50000AF11F /* Archive+sortEntries.swift */; };
 		OBJ_33 /* ZIPFoundationDataSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* ZIPFoundationDataSerializationTests.swift */; };
 		OBJ_34 /* ZIPFoundationEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* ZIPFoundationEntryTests.swift */; };
 		OBJ_35 /* ZIPFoundationFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* ZIPFoundationFileManagerTests.swift */; };
@@ -41,6 +42,7 @@
 		95B5A3D32366731B00D4D8FD /* Archive+MemoryFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+MemoryFile.swift"; sourceTree = "<group>"; };
 		95B5A3D52367983A00D4D8FD /* ZIPFoundationMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationMemoryTests.swift; sourceTree = "<group>"; };
 		BA3716A921F0A1AC006E54E6 /* ZIPFoundationProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationProgressTests.swift; sourceTree = "<group>"; };
+		D9C5971C251CBC50000AF11F /* Archive+sortEntries.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Archive+sortEntries.swift"; sourceTree = "<group>"; };
 		OBJ_10 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
 		OBJ_11 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				OBJ_9 /* Archive+Reading.swift */,
 				OBJ_10 /* Archive+Writing.swift */,
 				95B5A3D32366731B00D4D8FD /* Archive+MemoryFile.swift */,
+				D9C5971C251CBC50000AF11F /* Archive+sortEntries.swift */,
 				OBJ_14 /* Entry.swift */,
 				OBJ_12 /* Data+Compression.swift */,
 				OBJ_13 /* Data+Serialization.swift */,
@@ -256,6 +259,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D9C5971D251CBC50000AF11F /* Archive+sortEntries.swift in Sources */,
 				OBJ_48 /* Archive+Reading.swift in Sources */,
 				OBJ_49 /* Archive+Writing.swift in Sources */,
 				OBJ_50 /* Archive.swift in Sources */,


### PR DESCRIPTION
# Changes proposed in this PR

* Fix extraction order of symlinks

# Tests performed

- Existing tests
- Extracting the AltServer download from https://altstore.io/

# Further info for the reviewer

This needs more tests to ensure full coverage, but also to prove that this was previously broken and is now fixed.

The added function is public because I'm using it to extract a subset of the entries in the archive that contains symlinks.

# Open Issues

#185, possibly #62.