### PR TITLE
Disallow removal of entries from readonly archives

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -156,8 +156,7 @@ extension Archive {
         defer { try? manager.removeItem(at: tempDir) }
         let uniqueString = ProcessInfo.processInfo.globallyUniqueString
         let tempArchiveURL =  tempDir.appendingPathComponent(uniqueString)
-        do { try manager.createParentDirectoryStructure(for: tempArchiveURL) } catch {
-            throw ArchiveError.unwritableArchive }
+        try manager.createParentDirectoryStructure(for: tempArchiveURL)
         guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
             throw ArchiveError.unwritableArchive
         }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -150,6 +150,7 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
+        guard self.accessMode != .read else { throw ArchiveError.unwritableArchive }
         let manager = FileManager()
         let tempDir = self.uniqueTemporaryDirectoryURL()
         defer { try? manager.removeItem(at: tempDir) }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -73,7 +73,8 @@ class ZIPFoundationTests: XCTestCase {
         sourceArchiveURL.appendPathComponent(testFunction.replacingOccurrences(of: "()", with: ""))
         sourceArchiveURL.appendPathExtension("zip")
         var destinationArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
-        destinationArchiveURL.appendPathComponent(sourceArchiveURL.lastPathComponent)
+        destinationArchiveURL.appendPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        destinationArchiveURL.appendPathExtension("zip")
         do {
             if mode != .create {
                 let fileManager = FileManager()

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -299,6 +299,17 @@ extension ZIPFoundationTests {
             }
         }
         XCTAssertTrue(didCatchExpectedError)
+        didCatchExpectedError = false
+        let readonlyArchive = self.archive(for: #function, mode: .read)
+        do {
+            try readonlyArchive.remove(entryToRemove)
+        } catch let error as Archive.ArchiveError {
+            XCTAssertNotNil(error == .unwritableArchive)
+            didCatchExpectedError = true
+        } catch {
+            XCTFail("Unexpected error while trying to remove entry from readonly archive.")
+        }
+        XCTAssertTrue(didCatchExpectedError)
     }
 
     func testArchiveCreateErrorConditions() {


### PR DESCRIPTION
Fixes #198

# Changes proposed in this PR
* Guard against entry removal from archives initialized with mode `.read` 
* Make the behavior consistent with the `addEntry` method
* Add test coverage for the new error codepath 