### PR TITLE
Fix incorrect usage of MemoryLayout.size for MemoryLayout.stride

### DIFF
--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -94,13 +94,12 @@ extension Data {
         // The typecast is necessary on 32-bit platforms because of
         // https://bugs.swift.org/browse/SR-1774
         let mask = 0xffffffff as UInt32
-        let bufferSize = self.count/MemoryLayout<UInt8>.stride
         var result = checksum ^ mask
         #if swift(>=5.0)
         crcTable.withUnsafeBufferPointer { crcTablePointer in
             self.withUnsafeBytes { bufferPointer in
                 let bytePointer = bufferPointer.bindMemory(to: UInt8.self)
-                for bufferIndex in 0..<bufferSize {
+                for bufferIndex in 0..<self.count {
                     let byte = bytePointer[bufferIndex]
                     let index = Int((result ^ UInt32(byte)) & 0xff)
                     result = (result >> 8) ^ crcTablePointer[index]
@@ -109,11 +108,11 @@ extension Data {
         }
         #else
         self.withUnsafeBytes { (bytes) in
-            let bins = stride(from: 0, to: bufferSize, by: 256)
+            let bins = stride(from: 0, to: self.count, by: 256)
             for bin in bins {
                 for binIndex in 0..<256 {
                     let byteIndex = bin + binIndex
-                    guard byteIndex < bufferSize else { break }
+                    guard byteIndex < self.count else { break }
 
                     let byte = bytes[byteIndex]
                     let index = Int((result ^ UInt32(byte)) & 0xff)

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -94,7 +94,7 @@ extension Data {
         // The typecast is necessary on 32-bit platforms because of
         // https://bugs.swift.org/browse/SR-1774
         let mask = 0xffffffff as UInt32
-        let bufferSize = self.count/MemoryLayout<UInt8>.size
+        let bufferSize = self.count/MemoryLayout<UInt8>.stride
         var result = checksum ^ mask
         #if swift(>=5.0)
         crcTable.withUnsafeBufferPointer { crcTablePointer in


### PR DESCRIPTION
Fixes

Fix incorrect usage of `MemoryLayout.size` for `MemoryLayout.stride`.

[MemoryLayout](https://developer.apple.com/documentation/swift/memorylayout):

> Always use a multiple of a type’s stride instead of its size when allocating memory or accounting for the distance between instances in memory.

# Changes proposed in this PR

Fix incorrect usage of `MemoryLayout.size` for `MemoryLayout.stride`.

# Tests performed


# Further info for the reviewer


# Open Issues
