### PR TITLE
Add Objective-C support to extension of FileManager

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -27,7 +27,7 @@ let dataDescriptorStructSignature = 0x08074b50
 let centralDirectoryStructSignature = 0x02014b50
 
 /// The compression method of an `Entry` in a ZIP `Archive`.
-public enum CompressionMethod: UInt16 {
+@objc public enum CompressionMethod: UInt16 {
     /// Indicates that an `Entry` has no compression applied to its contents.
     case none = 0
     /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -29,7 +29,7 @@ extension FileManager {
     ///                        By default, `zipItem` will create uncompressed archives.
     ///   - progress: A progress object that can be used to track or cancel the zip operation.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
-    public func zipItem(at sourceURL: URL, to destinationURL: URL,
+    @objc public func zipItem(at sourceURL: URL, to destinationURL: URL,
                         shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .none,
                         progress: Progress? = nil) throws {
         let fileManager = FileManager()
@@ -129,6 +129,16 @@ extension FileManager {
                 _ = try archive.extract(entry, to: destinationEntryURL, skipCRC32: skipCRC32)
             }
         }
+    }
+
+    @objc public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
+                                progress: Progress? = nil, preferredEncoding: UInt) throws {
+        try unzipItem(at: sourceURL, to: destinationURL, skipCRC32: skipCRC32, progress: progress, preferredEncoding: String.Encoding(rawValue: preferredEncoding))
+    }
+
+    @objc public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
+                                progress: Progress? = nil) throws {
+        try unzipItem(at: sourceURL, to: destinationURL, skipCRC32: skipCRC32, progress: progress)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Fixes #

Package is impossible to use in mix Swift-Objective-C projects without writing some kind of wrapper.
Making whole package Objective-C compatible seems to be a big rework.
But `(NS)FileManager` is Objective-C class and it sounds reasonable if methods of its extension will be available to be used from Objective-C.

This PR proposes minor changes needed to make extension of `FileManager` available for Objective-C.

# Changes proposed in this PR
Makes following methods of `FileManager` extension available from Objective-C
* `zipItem(at sourceURL:to:shouldKeepParent:compressionMethod:progress:)`
* `unzipItem(at:to:skipCRC32:progress:preferredEncoding:)`

# Tests performed
If in general this PR would be accepted, I will add tests for new added methods.

# Further info for the reviewer
n/a

# Open Issues
n/a