### PR TITLE
Allow skipping checksum calculation when writing zip archives

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -264,7 +264,7 @@ extension Archive {
                                                                      progress: progress, provider: provider)
             case .deflate:
                 (sizeWritten, checksum) = try self.writeCompressed(size: localFileHeader.uncompressedSize,
-                                                                   bufferSize: bufferSize,
+                                                                   bufferSize: bufferSize, skipCRC32: skipCRC32,
                                                                    progress: progress, provider: provider)
             }
         case .directory:
@@ -297,11 +297,11 @@ extension Archive {
         return (UInt32(sizeWritten), checksum)
     }
 
-    private func writeCompressed(size: UInt32, bufferSize: UInt32, progress: Progress? = nil,
+    private func writeCompressed(size: UInt32, bufferSize: UInt32, skipCRC32: Bool, progress: Progress? = nil,
                                  provider: Provider) throws -> (sizeWritten: UInt32, checksum: CRC32) {
         var sizeWritten = 0
         let consumer: Consumer = { data in sizeWritten += try Data.write(chunk: data, to: self.archiveFile) }
-        let checksum = try Data.compress(size: Int(size), bufferSize: Int(bufferSize),
+        let checksum = try Data.compress(size: Int(size), bufferSize: Int(bufferSize), skipCRC32: skipCRC32,
                                          provider: { (position, size) -> Data in
                                             if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
                                             let data = try provider(position, size)

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -132,12 +132,12 @@ extension Data {
     ///   - provider: A closure that accepts a position and a chunk size. Returns a `Data` chunk.
     ///   - consumer: A closure that processes the result of the compress operation.
     /// - Returns: The checksum of the processed content.
-    public static func compress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    public static func compress(size: Int, bufferSize: Int, skipCRC32: Bool, provider: Provider, consumer: Consumer) throws -> CRC32 {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return try self.process(operation: COMPRESSION_STREAM_ENCODE, size: size, bufferSize: bufferSize,
+        return try self.process(operation: COMPRESSION_STREAM_ENCODE, size: size, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                 provider: provider, consumer: consumer)
         #else
-        return try self.encode(size: size, bufferSize: bufferSize, provider: provider, consumer: consumer)
+        return try self.encode(size: size, bufferSize: bufferSize, skipCRC32: skipCRC32, provider: provider, consumer: consumer)
         #endif
     }
 


### PR DESCRIPTION
Fixes performance being very slow with writing out large zip files (100 MB+)

# Changes proposed in this PR
* Add a parameter to skip calculating checksums when writing out zip archives, similar to the existing option for reading
* Parameter has a default values of false, so existing code will work the same without any API changes

# Tests performed
- All unit tests pass
- Zip files were written out, and then reopened successfully via macOS Archive Utility

# Further info for the reviewer


# Open Issues
