### PR TITLE
Fix overflow of file count

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -351,9 +351,21 @@ extension Archive {
         let centralDirectoryDataLengthChange = operation.rawValue * (dataLength + CentralDirectoryStructure.size)
         var updatedSizeOfCentralDirectory = Int(record.sizeOfCentralDirectory)
         updatedSizeOfCentralDirectory += centralDirectoryDataLengthChange
-        let numberOfEntriesOnDisk = UInt16(Int(record.totalNumberOfEntriesOnDisk) + countChange)
-        let numberOfEntriesInCentralDirectory = UInt16(Int(record.totalNumberOfEntriesInCentralDirectory) + countChange)
-        record = EndOfCentralDirectoryRecord(record: record, numberOfEntriesOnDisk: numberOfEntriesOnDisk,
+
+        let numberOfEntriesOnDiskInt = Int(record.totalNumberOfEntriesOnDisk) + countChange
+        guard numberOfEntriesOnDiskInt <= UInt16.max else {
+            throw ArchiveError.invalidNumberOfEntriesOnDisk
+        }
+        let numberOfEntriesOnDisk = UInt16(numberOfEntriesOnDiskInt)
+
+        let numberOfEntriesInCentralDirectoryInt = Int(record.totalNumberOfEntriesInCentralDirectory) + countChange
+        guard numberOfEntriesInCentralDirectoryInt <= UInt16.max else {
+            throw ArchiveError.invalidNumberOfEntriesInCentralDirectory
+        }
+        let numberOfEntriesInCentralDirectory = UInt16(numberOfEntriesInCentralDirectoryInt)
+
+        record = EndOfCentralDirectoryRecord(record: record,
+                                             numberOfEntriesOnDisk: numberOfEntriesOnDisk,
                                              numberOfEntriesInCentralDirectory: numberOfEntriesInCentralDirectory,
                                              updatedSizeOfCentralDirectory: UInt32(updatedSizeOfCentralDirectory),
                                              startOfCentralDirectory: startOfCentralDirectory)

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -79,6 +79,10 @@ public final class Archive: Sequence {
         case invalidStartOfCentralDirectoryOffset
         /// Thrown when an archive does not contain the required End of Central Directory Record.
         case missingEndOfCentralDirectoryRecord
+        /// Thrown when number of entries on disk exceeds `UInt16.max`
+        case invalidNumberOfEntriesOnDisk
+        /// Thrown when number of entries in central directory exceeds `UInt16.max`
+        case invalidNumberOfEntriesInCentralDirectory
         /// Thrown when an extract, add or remove operation was canceled.
         case cancelledOperation
         /// Thrown when an extract operation was called with zero or negative `bufferSize` parameter.

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -26,14 +26,6 @@ let localFileHeaderStructSignature = 0x04034b50
 let dataDescriptorStructSignature = 0x08074b50
 let centralDirectoryStructSignature = 0x02014b50
 
-/// The compression method of an `Entry` in a ZIP `Archive`.
-public enum CompressionMethod: UInt16 {
-    /// Indicates that an `Entry` has no compression applied to its contents.
-    case none = 0
-    /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.
-    case deflate = 8
-}
-
 /// A sequence of uncompressed or compressed ZIP entries.
 ///
 /// You use an `Archive` to create, read or update ZIP files.

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -10,6 +10,14 @@
 
 import Foundation
 
+/// The compression method of an `Entry` in a ZIP `Archive`.
+public enum CompressionMethod: UInt16 {
+    /// Indicates that an `Entry` has no compression applied to its contents.
+    case none = 0
+    /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.
+    case deflate = 8
+}
+
 /// An unsigned 32-Bit Integer representing a checksum.
 public typealias CRC32 = UInt32
 /// A custom handler that consumes a `Data` object containing partial entry data.

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -179,6 +179,8 @@ extension ZIPFoundationTests {
             ("testCreateArchiveAddLargeUncompressedEntry", testCreateArchiveAddLargeUncompressedEntry),
             ("testCreateArchiveAddSymbolicLink", testCreateArchiveAddSymbolicLink),
             ("testCreateArchiveAddTooLargeUncompressedEntry", testCreateArchiveAddTooLargeUncompressedEntry),
+            ("testCreateArchiveWithTooManyEntriesOnDisk", testCreateArchiveWithTooManyEntriesOnDisk),
+            ("testCreateArchiveWithTooManyDirectories", testCreateArchiveWithTooManyEntriesInCD),
             ("testCreateArchiveAddUncompressedEntry", testCreateArchiveAddUncompressedEntry),
             ("testDetectEntryType", testDetectEntryType),
             ("testExtractInvalidBufferSizeErrorConditions", testExtractInvalidBufferSizeErrorConditions),

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingOverflowTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingOverflowTests.swift
@@ -1,0 +1,78 @@
+//
+//  ZIPFoundationWritingTests.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017-2021 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import XCTest
+@testable import ZIPFoundation
+
+extension ZIPFoundationTests {
+
+    func testCreateArchiveWithTooManyEntriesOnDisk() {
+        let archive = self.archive(for: #function, mode: .create)
+        let fileName = ProcessInfo.processInfo.globallyUniqueString
+        var didCatchExpectedError = false
+
+        do {
+            try (1...UInt16.max).forEach { _ in
+                try archive.addEntry(with: fileName, type: .file, uncompressedSize: 1,
+                                     provider: { (_, chunkSize) -> Data in
+                    return Data(count: chunkSize)
+                })
+            }
+        } catch {
+            XCTFail("Unexpected error while trying to add an entry.")
+        }
+        do {
+            try archive.addEntry(with: fileName, type: .file, uncompressedSize: 1,
+                                 provider: { (_, chunkSize) -> Data in
+                return Data(count: chunkSize)
+            })
+        } catch let error as Archive.ArchiveError {
+            XCTAssert(error == .invalidNumberOfEntriesOnDisk)
+            didCatchExpectedError = true
+        } catch {
+            XCTFail("Unexpected error while trying to add an entry exceeding maximum size.")
+        }
+        XCTAssert(didCatchExpectedError)
+    }
+
+    func testCreateArchiveWithTooManyEntriesInCD() {
+        let archive = self.archive(for: #function, mode: .create)
+        let fileName = ProcessInfo.processInfo.globallyUniqueString
+        var didCatchExpectedError = false
+
+        let record = Archive.EndOfCentralDirectoryRecord(record: archive.endOfCentralDirectoryRecord,
+                                                         numberOfEntriesOnDisk: 0,
+                                                         numberOfEntriesInCentralDirectory: UInt16.max - 1,
+                                                         updatedSizeOfCentralDirectory: 0,
+                                                         startOfCentralDirectory: 0)
+        archive.endOfCentralDirectoryRecord = record
+
+        do {
+            try archive.addEntry(with: fileName, type: .file, uncompressedSize: 1,
+                                 provider: { (_, chunkSize) -> Data in
+                return Data(count: chunkSize)
+            })
+        } catch {
+            XCTFail("Unexpected error while trying to add an entry.")
+        }
+        do {
+            try archive.addEntry(with: fileName, type: .file, uncompressedSize: 1,
+                                 provider: { (_, chunkSize) -> Data in
+                return Data(count: chunkSize)
+            })
+        } catch let error as Archive.ArchiveError {
+            XCTAssert(error == .invalidNumberOfEntriesInCentralDirectory)
+            didCatchExpectedError = true
+        } catch {
+            XCTFail("Unexpected error while trying to add an entry exceeding maximum size.")
+        }
+        XCTAssert(didCatchExpectedError)
+    }
+}


### PR DESCRIPTION
Fixes file count overflow.

ZIPFoundation crashes at https://github.com/weichsel/ZIPFoundation/blob/cf10bbff6ac3b873e97b36b9784c79866a051a8e/Sources/ZIPFoundation/Archive%2BWriting.swift#L354 if file count exceeds 65535 (UInt16.max).

# Changes proposed in this PR
* Add overflow check for `NumberOfEntriesOnDisk` and `NumberOfEntriesInCentralDirectory `

# Tests performed
An error is thrown instead of crash if file count exceeds 65535.