### PR TITLE
fix crash if fopen returns nil

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -217,7 +217,6 @@ extension Archive {
                   let config = Archive.configureMemoryBacking(for: data, mode: .update) else {
                 throw ArchiveError.unwritableArchive
             }
-
             self.archiveFile = config.file
             self.memoryFile = config.memoryFile
             self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
@@ -236,7 +235,8 @@ extension Archive {
             _ = try fileManager.moveItem(at: archive.url, to: self.url)
             #endif
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: self.url.path)
-            self.archiveFile = fopen(fileSystemRepresentation, "rb+")
+            guard let file = fopen(fileSystemRepresentation, "rb+") else { throw ArchiveError.unreadableArchive }
+            self.archiveFile = file
         }
     }
 


### PR DESCRIPTION
Fixes crash that can happen if you try to save an archive to Google Drive in streaming mode

# Changes proposed in this PR
* throw instead of crash if fopen returns nil

# Tests performed


# Further info for the reviewer


# Open Issues
