### PR TITLE
Preserve extra field data during entry removal

### DIFF
--- a/Sources/ZIPFoundation/Entry+ZIP64.swift
+++ b/Sources/ZIPFoundation/Entry+ZIP64.swift
@@ -31,7 +31,7 @@ extension Entry {
     }
 
     var zip64ExtendedInformation: ZIP64ExtendedInformation? {
-        centralDirectoryStructure.zip64ExtendedInformation
+        self.centralDirectoryStructure.zip64ExtendedInformation
     }
 }
 

--- a/Sources/ZIPFoundation/Entry+ZIP64.swift
+++ b/Sources/ZIPFoundation/Entry+ZIP64.swift
@@ -40,8 +40,8 @@ typealias Field = Entry.ZIP64ExtendedInformation.Field
 extension Entry.LocalFileHeader {
     var validFields: [Field] {
         var fields: [Field] = []
-        if uncompressedSize == .max { fields.append(.uncompressedSize) }
-        if compressedSize == .max { fields.append(.compressedSize) }
+        if self.uncompressedSize == .max { fields.append(.uncompressedSize) }
+        if self.compressedSize == .max { fields.append(.compressedSize) }
         return fields
     }
 }
@@ -49,14 +49,14 @@ extension Entry.LocalFileHeader {
 extension Entry.CentralDirectoryStructure {
     var validFields: [Field] {
         var fields: [Field] = []
-        if uncompressedSize == .max { fields.append(.uncompressedSize) }
-        if compressedSize == .max { fields.append(.compressedSize) }
-        if relativeOffsetOfLocalHeader == .max { fields.append(.relativeOffsetOfLocalHeader) }
-        if diskNumberStart == .max { fields.append(.diskNumberStart) }
+        if self.uncompressedSize == .max { fields.append(.uncompressedSize) }
+        if self.compressedSize == .max { fields.append(.compressedSize) }
+        if self.relativeOffsetOfLocalHeader == .max { fields.append(.relativeOffsetOfLocalHeader) }
+        if self.diskNumberStart == .max { fields.append(.diskNumberStart) }
         return fields
     }
     var zip64ExtendedInformation: Entry.ZIP64ExtendedInformation? {
-        extraFields?.compactMap { $0 as? Entry.ZIP64ExtendedInformation }.first
+        self.extraFields?.compactMap { $0 as? Entry.ZIP64ExtendedInformation }.first
     }
 }
 

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -296,19 +296,19 @@ extension Entry.CentralDirectoryStructure {
 extension Entry.CentralDirectoryStructure {
 
     var effectiveCompressedSize: UInt64 {
-        if self.isZIP64, let compressedSize = zip64ExtendedInformation?.compressedSize, compressedSize > 0 {
+        if self.isZIP64, let compressedSize = self.zip64ExtendedInformation?.compressedSize, compressedSize > 0 {
             return compressedSize
         }
         return UInt64(compressedSize)
     }
     var effectiveUncompressedSize: UInt64 {
-        if self.isZIP64, let uncompressedSize = zip64ExtendedInformation?.uncompressedSize, uncompressedSize > 0 {
+        if self.isZIP64, let uncompressedSize = self.zip64ExtendedInformation?.uncompressedSize, uncompressedSize > 0 {
             return uncompressedSize
         }
         return UInt64(uncompressedSize)
     }
     var effectiveRelativeOffsetOfLocalHeader: UInt64 {
-        if self.isZIP64, let offset = zip64ExtendedInformation?.relativeOffsetOfLocalHeader, offset > 0 {
+        if self.isZIP64, let offset = self.zip64ExtendedInformation?.relativeOffsetOfLocalHeader, offset > 0 {
             return offset
         }
         return UInt64(relativeOffsetOfLocalHeader)

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -259,11 +259,11 @@ extension Entry.CentralDirectoryStructure {
     init(centralDirectoryStructure: Entry.CentralDirectoryStructure,
          zip64ExtendedInformation: Entry.ZIP64ExtendedInformation?, relativeOffset: UInt32) {
         if let existingInfo = zip64ExtendedInformation {
-            extraFieldData = existingInfo.data
-            versionNeededToExtract = max(centralDirectoryStructure.versionNeededToExtract, Archive.Version.v45.rawValue)
+            self.extraFieldData = existingInfo.data
+            self.versionNeededToExtract = max(centralDirectoryStructure.versionNeededToExtract, Archive.Version.v45.rawValue)
         } else {
-            extraFieldData = Data()
-            versionNeededToExtract = centralDirectoryStructure.versionNeededToExtract < Archive.Version.v45.rawValue
+            self.extraFieldData = centralDirectoryStructure.extraFieldData
+            self.versionNeededToExtract = centralDirectoryStructure.versionNeededToExtract < Archive.Version.v45.rawValue
                 ? centralDirectoryStructure.versionNeededToExtract
                 : Archive.Version.v20.rawValue
         }

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -260,10 +260,12 @@ extension Entry.CentralDirectoryStructure {
          zip64ExtendedInformation: Entry.ZIP64ExtendedInformation?, relativeOffset: UInt32) {
         if let existingInfo = zip64ExtendedInformation {
             self.extraFieldData = existingInfo.data
-            self.versionNeededToExtract = max(centralDirectoryStructure.versionNeededToExtract, Archive.Version.v45.rawValue)
+            self.versionNeededToExtract = max(centralDirectoryStructure.versionNeededToExtract,
+                                              Archive.Version.v45.rawValue)
         } else {
             self.extraFieldData = centralDirectoryStructure.extraFieldData
-            self.versionNeededToExtract = centralDirectoryStructure.versionNeededToExtract < Archive.Version.v45.rawValue
+            let existingVersion = centralDirectoryStructure.versionNeededToExtract
+            self.versionNeededToExtract = existingVersion < Archive.Version.v45.rawValue
                 ? centralDirectoryStructure.versionNeededToExtract
                 : Archive.Version.v20.rawValue
         }


### PR DESCRIPTION
Fixes #238

# Changes proposed in this PR
* Preserve existing ZIP extra field data when removing entries
