### PR TITLE
Port to Android

### DIFF
--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -13,13 +13,13 @@ import Foundation
 extension Archive {
 
     struct BackingConfiguration {
-        let file: UnsafeMutablePointer<FILE>
+        let file: FILEPointer
         let endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
         let zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
         #if swift(>=5.0)
         let memoryFile: MemoryFile?
 
-        init(file: UnsafeMutablePointer<FILE>,
+        init(file: FILEPointer,
              endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord,
              zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory? = nil,
              memoryFile: MemoryFile? = nil) {
@@ -30,7 +30,7 @@ extension Archive {
         }
         #else
 
-        init(file: UnsafeMutablePointer<FILE>,
+        init(file: FILEPointer,
              endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord,
              zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?) {
             self.file = file

--- a/Sources/ZIPFoundation/Archive+MemoryFile.swift
+++ b/Sources/ZIPFoundation/Archive+MemoryFile.swift
@@ -29,11 +29,11 @@ class MemoryFile {
         self.data = data
     }
 
-    func open(mode: String) -> UnsafeMutablePointer<FILE>? {
+    func open(mode: String) -> FILEPointer? {
         let cookie = Unmanaged.passRetained(self)
         let writable = mode.count > 0 && (mode.first! != "r" || mode.last! == "+")
         let append = mode.count > 0 && mode.first! == "a"
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
         let result = writable
             ? funopen(cookie.toOpaque(), readStub, writeStub, seekStub, closeStub)
             : funopen(cookie.toOpaque(), readStub, nil, seekStub, closeStub)
@@ -99,7 +99,7 @@ private func closeStub(_ cookie: UnsafeMutableRawPointer?) -> Int32 {
     return 0
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
 private func readStub(_ cookie: UnsafeMutableRawPointer?,
                       _ bytePtr: UnsafeMutablePointer<Int8>?,
                       _ count: Int32) -> Int32 {

--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -35,7 +35,7 @@ extension Archive {
             }
             try fileManager.createParentDirectoryStructure(for: url)
             let destinationRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
-            guard let destinationFile: UnsafeMutablePointer<FILE> = fopen(destinationRepresentation, "wb+") else {
+            guard let destinationFile: FILEPointer = fopen(destinationRepresentation, "wb+") else {
                 throw CocoaError(.fileNoSuchFile)
             }
             defer { fclose(destinationFile) }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -66,7 +66,7 @@ extension Archive {
         switch type {
         case .file:
             let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-            guard let entryFile: UnsafeMutablePointer<FILE> = fopen(entryFileSystemRepresentation, "rb") else {
+            guard let entryFile: FILEPointer = fopen(entryFileSystemRepresentation, "rb") else {
                 throw CocoaError(.fileNoSuchFile)
             }
             defer { fclose(entryFile) }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -126,7 +126,7 @@ public final class Archive: Sequence {
     public let url: URL
     /// Access mode for an archive file.
     public let accessMode: AccessMode
-    var archiveFile: UnsafeMutablePointer<FILE>
+    var archiveFile: FILEPointer
     var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
     var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
     var preferredEncoding: String.Encoding?
@@ -267,7 +267,7 @@ public final class Archive: Sequence {
 
     // MARK: - Helpers
 
-    static func scanForEndOfCentralDirectoryRecord(in file: UnsafeMutablePointer<FILE>)
+    static func scanForEndOfCentralDirectoryRecord(in file: FILEPointer)
         -> EndOfCentralDirectoryStructure? {
         var eocdOffset: UInt64 = 0
         var index = minEndOfCentralDirectoryOffset
@@ -290,7 +290,7 @@ public final class Archive: Sequence {
         return nil
     }
 
-    private static func scanForZIP64EndOfCentralDirectory(in file: UnsafeMutablePointer<FILE>, eocdOffset: UInt64)
+    private static func scanForZIP64EndOfCentralDirectory(in file: FILEPointer, eocdOffset: UInt64)
         -> ZIP64EndOfCentralDirectory? {
         guard UInt64(ZIP64EndOfCentralDirectoryLocator.size) < eocdOffset else {
             return nil

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -255,7 +255,7 @@ extension FileManager {
         let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
         var fileStat = stat()
         lstat(entryFileSystemRepresentation, &fileStat)
-        return Entry.EntryType(mode: fileStat.st_mode)
+        return Entry.EntryType(mode: mode_t(fileStat.st_mode))
     }
 }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
@@ -21,7 +21,7 @@ extension ZIPFoundationTests {
                                             attributes: nil)
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-        let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb")
+        let file: FILEPointer = fopen(fileSystemRepresentation, "rb")
         // Close the file to exercise the error path during readStructure that deals with
         // unreadable file data.
         fclose(file)
@@ -38,7 +38,7 @@ extension ZIPFoundationTests {
                                             attributes: nil)
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-        let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb")
+        let file: FILEPointer = fopen(fileSystemRepresentation, "rb")
         // Close the file to exercise the error path during readChunk that deals with
         // unreadable file data.
         fclose(file)
@@ -60,7 +60,7 @@ extension ZIPFoundationTests {
                                             attributes: nil)
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-        let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb")
+        let file: FILEPointer = fopen(fileSystemRepresentation, "rb")
         // Close the file to exercise the error path during writeChunk that deals with
         // unwritable files.
         fclose(file)
@@ -92,7 +92,7 @@ extension ZIPFoundationTests {
                                             attributes: nil)
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-        let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb+")
+        let file: FILEPointer = fopen(fileSystemRepresentation, "rb+")
         let data = Data.makeRandomData(size: 1024)
         do {
             let writtenSize = try Data.writeLargeChunk(data, size: 1024, bufferSize: 256, to: file)
@@ -114,7 +114,7 @@ extension ZIPFoundationTests {
                                             attributes: nil)
         XCTAssert(result == true)
         let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: fileURL.path)
-        let file: UnsafeMutablePointer<FILE> = fopen(fileSystemRepresentation, "rb")
+        let file: FILEPointer = fopen(fileSystemRepresentation, "rb")
         let data = Data.makeRandomData(size: 1024)
         // Close the file to exercise the error path during writeChunk that deals with
         // unwritable files.

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -154,7 +154,7 @@ extension ZIPFoundationTests {
         let archiveURL = self.resourceURL(for: #function, pathExtension: "zip")
         let fileManager = FileManager()
         let destinationFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: archiveURL.path)
-        let destinationFile: UnsafeMutablePointer<FILE> = fopen(destinationFileSystemRepresentation, "r+b")
+        let destinationFile: FILEPointer = fopen(destinationFileSystemRepresentation, "r+b")
 
         do {
             fseek(destinationFile, 64, SEEK_SET)

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -137,7 +137,7 @@ class ZIPFoundationTests: XCTestCase {
     }
 
     func runWithFileDescriptorLimit(_ limit: UInt64, handler: () -> Void) {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
         let fileNoFlag = RLIMIT_NOFILE
         #else
         let fileNoFlag = Int32(RLIMIT_NOFILE.rawValue)


### PR DESCRIPTION
# Changes proposed in this PR
* Add a `FILEPointer` type alias, as `FILE` is an opaque struct since Android 7.
* Add Android to existing OS specializations where needed.
* Convert to `mode_t` in `FIleManager+ZIP` for Android armv7, where `mode_t` is narrower than `st_mode`.

# Tests performed
I ran `swift test` on both linux x86_64 and Android AArch64 with this pull and all tests passed. 

# Further info for the reviewer
I used this pull when porting CookCLI as a package for Android, termux/termux-packages#11081. I used a similar typealias when porting apple/swift-tools-support-core#243 for Android last year.

# Open Issues
None
