### PR TITLE
Make the `DataError` type `public`

### DIFF
--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -23,7 +23,7 @@ protocol DataSerializable {
 }
 
 extension Data {
-    enum DataError: Error {
+    public enum DataError: Error {
         case unreadableFile
         case unwritableFile
     }


### PR DESCRIPTION
Fixes #268 

The goal of this PR is to make the `DataError` type `public` so that allowing the developers to handle this type of error in their apps.