### PR TITLE
Throwing Archive Init

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        tag: ['5.1', '5.2', '5.3']
+        tag: ['5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}

--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -50,7 +50,7 @@ extension Archive {
                 throw POSIXError(errno, path: url.path)
             }
             guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
-                throw ArchiveError.unreadableArchive
+                throw ArchiveError.missingEndOfCentralDirectoryRecord
             }
             return BackingConfiguration(file: archiveFile,
                                         endOfCentralDirectoryRecord: eocdRecord,
@@ -72,7 +72,7 @@ extension Archive {
                 throw POSIXError(errno, path: url.path)
             }
             guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
-                throw ArchiveError.unwritableArchive
+                throw ArchiveError.missingEndOfCentralDirectoryRecord
             }
             fseeko(archiveFile, 0, SEEK_SET)
             return BackingConfiguration(file: archiveFile,

--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -46,9 +46,10 @@ extension Archive {
         switch mode {
         case .read:
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
-            // TODO: enhancement/throwingArchiveInit - throw specific error.
-            guard let archiveFile = fopen(fileSystemRepresentation, "rb"),
-                  let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+            guard let archiveFile = fopen(fileSystemRepresentation, "rb") else {
+                throw POSIXError(errno, path: url.path)
+            }
+            guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
                 throw ArchiveError.unreadableArchive
             }
             return BackingConfiguration(file: archiveFile,
@@ -67,9 +68,10 @@ extension Archive {
             fallthrough
         case .update:
             let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
-            // TODO: enhancement/throwingArchiveInit - throw specific error.
-            guard let archiveFile = fopen(fileSystemRepresentation, "rb+"),
-                  let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+            guard let archiveFile = fopen(fileSystemRepresentation, "rb+") else {
+                throw POSIXError(errno, path: url.path)
+            }
+            guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
                 throw ArchiveError.unwritableArchive
             }
             fseeko(archiveFile, 0, SEEK_SET)

--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -63,7 +63,6 @@ extension Archive {
                                                                           offsetToStartOfCentralDirectory: 0,
                                                                           zipFileCommentLength: 0,
                                                                           zipFileCommentData: Data())
-
             try endOfCentralDirectoryRecord.data.write(to: url, options: .withoutOverwriting)
             fallthrough
         case .update:

--- a/Sources/ZIPFoundation/Archive+Deprecated.swift
+++ b/Sources/ZIPFoundation/Archive+Deprecated.swift
@@ -11,7 +11,7 @@ public extension Archive {
 
     @available(*, deprecated, message: "Please use the throwing initializer.")
     convenience init?(url: URL, accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
-        self.init(url: url, accessMode: mode, pathEncoding: preferredEncoding)
+        try? self.init(url: url, accessMode: mode, pathEncoding: preferredEncoding)
     }
 
 #if swift(>=5.0)

--- a/Sources/ZIPFoundation/Archive+Deprecated.swift
+++ b/Sources/ZIPFoundation/Archive+Deprecated.swift
@@ -17,7 +17,7 @@ public extension Archive {
 #if swift(>=5.0)
     @available(*, deprecated, message: "Please use the throwing initializer.")
     convenience init?(data: Data = Data(), accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
-        self.init(data: data, accessMode: mode, pathEncoding: preferredEncoding)
+        try? self.init(data: data, accessMode: mode, pathEncoding: preferredEncoding)
     }
 #endif
 }

--- a/Sources/ZIPFoundation/Archive+Deprecated.swift
+++ b/Sources/ZIPFoundation/Archive+Deprecated.swift
@@ -1,0 +1,23 @@
+//
+//  Archive+Deprecated.swift
+//  ZIPFoundation
+//
+//  Created by Thomas Zoechling on 06.02.23.
+//
+
+import Foundation
+
+public extension Archive {
+
+    @available(*, deprecated, message: "Please use the throwing initializer.")
+    convenience init?(url: URL, accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
+        self.init(url: url, accessMode: mode, pathEncoding: preferredEncoding)
+    }
+
+#if swift(>=5.0)
+    @available(*, deprecated, message: "Please use the throwing initializer.")
+    convenience init?(data: Data = Data(), accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
+        self.init(data: data, accessMode: mode, pathEncoding: preferredEncoding)
+    }
+#endif
+}

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -285,7 +285,7 @@ private extension Archive {
         if self.isMemoryArchive {
             #if swift(>=5.0)
             guard let tempArchive = Archive(data: Data(), accessMode: .create,
-                                            preferredEncoding: self.preferredEncoding) else {
+                                            pathEncoding: self.pathEncoding) else {
                 throw ArchiveError.unwritableArchive
             }
             archive = tempArchive

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -221,10 +221,11 @@ extension Archive {
         fclose(self.archiveFile)
         if self.isMemoryArchive {
             #if swift(>=5.0)
-            guard let data = archive.data,
-                  let config = Archive.makeBackingConfiguration(for: data, mode: .update) else {
+            guard let data = archive.data else {
                 throw ArchiveError.unwritableArchive
             }
+
+            let config = try Archive.makeBackingConfiguration(for: data, mode: .update)
             self.archiveFile = config.file
             self.memoryFile = config.memoryFile
             self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
@@ -284,11 +285,8 @@ private extension Archive {
         var url: URL?
         if self.isMemoryArchive {
             #if swift(>=5.0)
-            guard let tempArchive = Archive(data: Data(), accessMode: .create,
-                                            pathEncoding: self.pathEncoding) else {
-                throw ArchiveError.unwritableArchive
-            }
-            archive = tempArchive
+            archive = try Archive(data: Data(), accessMode: .create,
+                                  pathEncoding: self.pathEncoding)
             #else
             fatalError("Memory archives are unsupported.")
             #endif

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -298,9 +298,7 @@ private extension Archive {
             let uniqueString = ProcessInfo.processInfo.globallyUniqueString
             let tempArchiveURL = tempDir.appendingPathComponent(uniqueString)
             try manager.createParentDirectoryStructure(for: tempArchiveURL)
-            guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
-                throw ArchiveError.unwritableArchive
-            }
+            let tempArchive = try Archive(url: tempArchiveURL, accessMode: .create)
             archive = tempArchive
             url = tempDir
         }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -161,13 +161,11 @@ public final class Archive: Sequence {
     ///   - The file URL _must_ point to an existing file for `AccessMode.read`.
     ///   - The file URL _must_ point to a non-existing file for `AccessMode.create`.
     ///   - The file URL _must_ point to an existing file for `AccessMode.update`.
-    public init?(url: URL, accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) {
+    public init(url: URL, accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) throws {
         self.url = url
         self.accessMode = mode
         self.pathEncoding = pathEncoding
-        guard let config = Archive.makeBackingConfiguration(for: url, mode: mode) else {
-            return nil
-        }
+        let config = try Archive.makeBackingConfiguration(for: url, mode: mode)
         self.archiveFile = config.file
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -54,6 +54,7 @@ let memoryURLScheme = "memory"
 ///     var archive = Archive(url: archiveURL, accessMode: .update)
 ///     try archive?.addEntry("test.txt", relativeTo: baseURL, compressionMethod: .deflate)
 public final class Archive: Sequence {
+
     typealias LocalFileHeader = Entry.LocalFileHeader
     typealias DataDescriptor = Entry.DefaultDataDescriptor
     typealias ZIP64DataDescriptor = Entry.ZIP64DataDescriptor
@@ -259,7 +260,7 @@ public final class Archive: Sequence {
     /// - Parameter path: A relative file path identifying the corresponding `Entry`.
     /// - Returns: An `Entry` with the given `path`. Otherwise, `nil`.
     public subscript(path: String) -> Entry? {
-        if let encoding = preferredEncoding {
+        if let encoding = self.preferredEncoding {
             return self.first { $0.path(using: encoding) == path }
         }
         return self.first { $0.path == path }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -189,16 +189,15 @@ public final class Archive: Sequence {
     /// - Note:
     ///   - The backing `data` _must_ contain a valid ZIP archive for `AccessMode.read` and `AccessMode.update`.
     ///   - The backing `data` _must_ be empty (or omitted) for `AccessMode.create`.
-    public init?(data: Data = Data(), accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) {
-        guard let url = URL(string: "\(memoryURLScheme)://"),
-              let config = Archive.makeBackingConfiguration(for: data, mode: mode) else {
-            // TODO: enhancement/throwingArchiveInit - make in-memory archive init `throwing`
-            return nil
+    public init(data: Data = Data(), accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) throws {
+        guard let url = URL(string: "\(memoryURLScheme)://") else {
+            throw ArchiveError.unreadableArchive
         }
 
         self.url = url
         self.accessMode = mode
         self.pathEncoding = pathEncoding
+        let config = try Archive.makeBackingConfiguration(for: data, mode: mode)
         self.archiveFile = config.file
         self.memoryFile = config.memoryFile
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -192,6 +192,7 @@ public final class Archive: Sequence {
     public init?(data: Data = Data(), accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) {
         guard let url = URL(string: "\(memoryURLScheme)://"),
               let config = Archive.makeBackingConfiguration(for: data, mode: mode) else {
+            // TODO: enhancement/throwingArchiveInit - make in-memory archive init `throwing`
             return nil
         }
 

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -130,19 +130,19 @@ public final class Archive: Sequence {
     var archiveFile: FILEPointer
     var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
     var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
-    var preferredEncoding: String.Encoding?
+    var pathEncoding: String.Encoding?
 
     var totalNumberOfEntriesInCentralDirectory: UInt64 {
         zip64EndOfCentralDirectory?.record.totalNumberOfEntriesInCentralDirectory
-            ?? UInt64(endOfCentralDirectoryRecord.totalNumberOfEntriesInCentralDirectory)
+        ?? UInt64(endOfCentralDirectoryRecord.totalNumberOfEntriesInCentralDirectory)
     }
     var sizeOfCentralDirectory: UInt64 {
         zip64EndOfCentralDirectory?.record.sizeOfCentralDirectory
-            ?? UInt64(endOfCentralDirectoryRecord.sizeOfCentralDirectory)
+        ?? UInt64(endOfCentralDirectoryRecord.sizeOfCentralDirectory)
     }
     var offsetToStartOfCentralDirectory: UInt64 {
         zip64EndOfCentralDirectory?.record.offsetToStartOfCentralDirectory
-            ?? UInt64(endOfCentralDirectoryRecord.offsetToStartOfCentralDirectory)
+        ?? UInt64(endOfCentralDirectoryRecord.offsetToStartOfCentralDirectory)
     }
 
     /// Initializes a new ZIP `Archive`.
@@ -152,19 +152,19 @@ public final class Archive: Sequence {
     /// - Parameters:
     ///   - url: File URL to the receivers backing file.
     ///   - mode: Access mode of the receiver.
-    ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
-    ///                        This encoding is only used when _decoding_ paths from the receiver.
-    ///                        Paths of entries added with `addEntry` are always UTF-8 encoded.
+    ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///                   This encoding is only used when _decoding_ paths from the receiver.
+    ///                   Paths of entries added with `addEntry` are always UTF-8 encoded.
     /// - Returns: An archive initialized with a backing file at the passed in file URL and the given access mode
     ///   or `nil` if the following criteria are not met:
     /// - Note:
     ///   - The file URL _must_ point to an existing file for `AccessMode.read`.
     ///   - The file URL _must_ point to a non-existing file for `AccessMode.create`.
     ///   - The file URL _must_ point to an existing file for `AccessMode.update`.
-    public init?(url: URL, accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
+    public init?(url: URL, accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) {
         self.url = url
         self.accessMode = mode
-        self.preferredEncoding = preferredEncoding
+        self.pathEncoding = pathEncoding
         guard let config = Archive.makeBackingConfiguration(for: url, mode: mode) else {
             return nil
         }
@@ -174,7 +174,7 @@ public final class Archive: Sequence {
         setvbuf(self.archiveFile, nil, _IOFBF, Int(defaultPOSIXBufferSize))
     }
 
-    #if swift(>=5.0)
+#if swift(>=5.0)
     var memoryFile: MemoryFile?
 
     /// Initializes a new in-memory ZIP `Archive`.
@@ -184,28 +184,28 @@ public final class Archive: Sequence {
     /// - Parameters:
     ///   - data: `Data` object used as backing for in-memory archives.
     ///   - mode: Access mode of the receiver.
-    ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
-    ///                        This encoding is only used when _decoding_ paths from the receiver.
-    ///                        Paths of entries added with `addEntry` are always UTF-8 encoded.
+    ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///                   This encoding is only used when _decoding_ paths from the receiver.
+    ///                   Paths of entries added with `addEntry` are always UTF-8 encoded.
     /// - Returns: An in-memory archive initialized with passed in backing data.
     /// - Note:
     ///   - The backing `data` _must_ contain a valid ZIP archive for `AccessMode.read` and `AccessMode.update`.
     ///   - The backing `data` _must_ be empty (or omitted) for `AccessMode.create`.
-    public init?(data: Data = Data(), accessMode mode: AccessMode, preferredEncoding: String.Encoding? = nil) {
+    public init?(data: Data = Data(), accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) {
         guard let url = URL(string: "\(memoryURLScheme)://"),
-            let config = Archive.makeBackingConfiguration(for: data, mode: mode) else {
+              let config = Archive.makeBackingConfiguration(for: data, mode: mode) else {
             return nil
         }
 
         self.url = url
         self.accessMode = mode
-        self.preferredEncoding = preferredEncoding
+        self.pathEncoding = pathEncoding
         self.archiveFile = config.file
         self.memoryFile = config.memoryFile
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory
     }
-    #endif
+#endif
 
     deinit {
         fclose(self.archiveFile)
@@ -219,7 +219,7 @@ public final class Archive: Sequence {
             guard index < totalNumberOfEntriesInCD else { return nil }
             guard let centralDirStruct: CentralDirectoryStructure = Data.readStruct(from: self.archiveFile,
                                                                                     at: directoryIndex) else {
-                                                                                        return nil
+                return nil
             }
             let offset = UInt64(centralDirStruct.effectiveRelativeOffsetOfLocalHeader)
             guard let localFileHeader: LocalFileHeader = Data.readStruct(from: self.archiveFile,
@@ -230,8 +230,8 @@ public final class Archive: Sequence {
                 let additionalSize = UInt64(localFileHeader.fileNameLength) + UInt64(localFileHeader.extraFieldLength)
                 let isCompressed = centralDirStruct.compressionMethod != CompressionMethod.none.rawValue
                 let dataSize = isCompressed
-                    ? centralDirStruct.effectiveCompressedSize
-                    : centralDirStruct.effectiveUncompressedSize
+                ? centralDirStruct.effectiveCompressedSize
+                : centralDirStruct.effectiveUncompressedSize
                 let descriptorPosition = offset + UInt64(LocalFileHeader.size) + additionalSize + dataSize
                 if centralDirStruct.isZIP64 {
                     zip64DataDescriptor = Data.readStruct(from: self.archiveFile, at: descriptorPosition)
@@ -260,7 +260,7 @@ public final class Archive: Sequence {
     /// - Parameter path: A relative file path identifying the corresponding `Entry`.
     /// - Returns: An `Entry` with the given `path`. Otherwise, `nil`.
     public subscript(path: String) -> Entry? {
-        if let encoding = self.preferredEncoding {
+        if let encoding = self.pathEncoding {
             return self.first { $0.path(using: encoding) == path }
         }
         return self.first { $0.path == path }
@@ -269,7 +269,7 @@ public final class Archive: Sequence {
     // MARK: - Helpers
 
     static func scanForEndOfCentralDirectoryRecord(in file: FILEPointer)
-        -> EndOfCentralDirectoryStructure? {
+    -> EndOfCentralDirectoryStructure? {
         var eocdOffset: UInt64 = 0
         var index = minEndOfCentralDirectoryOffset
         fseeko(file, 0, SEEK_END)
@@ -292,7 +292,7 @@ public final class Archive: Sequence {
     }
 
     private static func scanForZIP64EndOfCentralDirectory(in file: FILEPointer, eocdOffset: UInt64)
-        -> ZIP64EndOfCentralDirectory? {
+    -> ZIP64EndOfCentralDirectory? {
         guard UInt64(ZIP64EndOfCentralDirectoryLocator.size) < eocdOffset else {
             return nil
         }
@@ -311,6 +311,7 @@ public final class Archive: Sequence {
 }
 
 extension Archive.EndOfCentralDirectoryRecord {
+
     var data: Data {
         var endOfCDSignature = self.endOfCentralDirectorySignature
         var numberOfDisk = self.numberOfDisk

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -89,15 +89,15 @@ extension FileManager {
     ///   - destinationURL: The file URL that identifies the destination directory of the unzip operation.
     ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
-    ///   - preferredEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
-                          progress: Progress? = nil, preferredEncoding: String.Encoding? = nil) throws {
+                          progress: Progress? = nil, pathEncoding: String.Encoding? = nil) throws {
         let fileManager = FileManager()
         guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
         }
-        guard let archive = Archive(url: sourceURL, accessMode: .read, preferredEncoding: preferredEncoding) else {
+        guard let archive = Archive(url: sourceURL, accessMode: .read, preferredEncoding: pathEncoding) else {
             throw Archive.ArchiveError.unreadableArchive
         }
 
@@ -108,7 +108,7 @@ extension FileManager {
         }
 
         for entry in archive {
-            let path = preferredEncoding == nil ? entry.path : entry.path(using: preferredEncoding!)
+            let path = pathEncoding == nil ? entry.path : entry.path(using: pathEncoding!)
             let entryURL = destinationURL.appendingPathComponent(path)
             guard entryURL.isContained(in: destinationURL) else {
                 throw CocoaError(.fileReadInvalidFileName,

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -316,13 +316,9 @@ extension FileManager {
 
 extension POSIXError {
 
-    init(_ code: Int32, path: String? = nil) {
+    init(_ code: Int32, path: String) {
         let errorCode = POSIXError.Code(rawValue: code) ?? .EPERM
-        if let path = path {
-            self = .init(errorCode, userInfo: [NSFilePathErrorKey: path])
-        } else {
-            self = .init(errorCode)
-        }
+        self = .init(errorCode, userInfo: [NSFilePathErrorKey: path])
     }
 }
 

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -316,9 +316,13 @@ extension FileManager {
 
 extension POSIXError {
 
-    init(_ code: Int32, path: String) {
+    init(_ code: Int32, path: String? = nil) {
         let errorCode = POSIXError.Code(rawValue: code) ?? .EPERM
-        self = .init(errorCode, userInfo: [NSFilePathErrorKey: path])
+        if let path = path {
+            self = .init(errorCode, userInfo: [NSFilePathErrorKey: path])
+        } else {
+            self = .init(errorCode)
+        }
     }
 }
 

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -11,6 +11,7 @@
 import Foundation
 
 extension FileManager {
+
     typealias CentralDirectoryStructure = Entry.CentralDirectoryStructure
 
     /// Zips the file or directory contents at the specified source URL to the destination URL.
@@ -39,9 +40,7 @@ extension FileManager {
         guard !fileManager.itemExists(at: destinationURL) else {
             throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: destinationURL.path])
         }
-        guard let archive = Archive(url: destinationURL, accessMode: .create) else {
-            throw Archive.ArchiveError.unwritableArchive
-        }
+        let archive = try Archive(url: destinationURL, accessMode: .create)
         let isDirectory = try FileManager.typeForItem(at: sourceURL) == .directory
         if isDirectory {
             var subPaths = try self.subpathsOfDirectory(atPath: sourceURL.path)
@@ -97,10 +96,7 @@ extension FileManager {
         guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
         }
-        guard let archive = Archive(url: sourceURL, accessMode: .read, preferredEncoding: pathEncoding) else {
-            throw Archive.ArchiveError.unreadableArchive
-        }
-
+        let archive = try Archive(url: sourceURL, accessMode: .read, pathEncoding: pathEncoding)
         var totalUnitCount = Int64(0)
         if let progress = progress {
             totalUnitCount = archive.reduce(0, { $0 + archive.totalUnitCountForReading($1) })

--- a/Sources/ZIPFoundation/FileManager+ZIPDeprecated.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIPDeprecated.swift
@@ -1,0 +1,18 @@
+//
+//  FileManager+ZIPDeprecated.swift
+//  ZIPFoundation
+//
+//  Created by Thomas Zoechling on 06.02.23.
+//
+
+import Foundation
+
+public extension FileManager {
+
+    @available(*, deprecated, renamed: "unzipItem(at:to:skipCRC32:progress:pathEncoding:)")
+    func unzipItem(at sourceURL: URL, to destinationURL: URL, skipCRC32: Bool = false,
+                   progress: Progress? = nil, preferredEncoding: String.Encoding?) throws {
+        try self.unzipItem(at: sourceURL, to: destinationURL, skipCRC32: skipCRC32,
+                           progress: progress, pathEncoding: preferredEncoding)
+    }
+}

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
@@ -84,7 +84,15 @@ extension XCTestCase {
                                 in file: StaticString = #file,
                                 line: UInt = #line) {
         var thrownError: CocoaError?
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? CocoaError}
+        #else
+        XCTAssertThrowsError(try expression(), file: file, line: line) {
+            // For unknown reasons, some errors in the `NSCocoaErrorDomain` can't be cast to `CocoaError` on Linux.
+            // We manually re-create them here as `CocoaError` to work around this.
+            thrownError = CocoaError(.init(rawValue: ($0 as NSError).code))
+        }
+        #endif
         XCTAssertNotNil(thrownError, file: file, line: line)
         XCTAssertTrue(thrownError?.code == code, file: file, line: line)
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
@@ -74,11 +74,7 @@ extension XCTestCase {
                                 in file: StaticString = #file,
                                 line: UInt = #line) {
         var thrownError: POSIXError?
-        XCTAssertThrowsError(try expression(), file: file, line: line) {
-            // This cast is necessary on non-Darwin platforms. Error bridging behaves slightly different there.
-            let nsError = $0 as NSError
-            thrownError = POSIXError(Int32(nsError.code), path: nsError.userInfo[NSFilePathErrorKey] as? String)
-        }
+        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? POSIXError }
         XCTAssertNotNil(thrownError, file: file, line: line)
         XCTAssertTrue(thrownError?.code == code, file: file, line: line)
     }
@@ -88,11 +84,7 @@ extension XCTestCase {
                                 in file: StaticString = #file,
                                 line: UInt = #line) {
         var thrownError: CocoaError?
-        XCTAssertThrowsError(try expression(), file: file, line: line) {
-            // This cast is necessary on non-Darwin platforms. Error bridging behaves slightly different there.
-            let nsError = $0 as NSError
-            thrownError = CocoaError(CocoaError.Code(rawValue: nsError.code), userInfo: nsError.userInfo)
-        }
+        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? CocoaError}
         XCTAssertNotNil(thrownError, file: file, line: line)
         XCTAssertTrue(thrownError?.code == code, file: file, line: line)
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
@@ -35,7 +35,7 @@ extension ZIPFoundationTests {
         } catch { XCTFail("Failed to create parent directory.") }
     }
 
-    func testTemporaryReplacementDirectoryURL() {
+    func testTemporaryReplacementDirectoryURL() throws {
         let archive = self.archive(for: #function, mode: .create)
         var tempURLs = Set<URL>()
         defer { for url in tempURLs { try? FileManager.default.removeItem(at: url) } }
@@ -50,11 +50,7 @@ extension ZIPFoundationTests {
         // Also cover the fallback codepath in the helper method to generate a unique temp URL.
         // In-memory archives have no filesystem representation and therefore don't need a per-volume
         // temp URL.
-        guard let memoryArchive = Archive(data: Data(), accessMode: .create) else {
-            XCTFail("Temporary memory archive creation failed.")
-            return
-        }
-
+        let memoryArchive = try Archive(data: Data(), accessMode: .create)
         let memoryTempURL = URL.temporaryReplacementDirectoryURL(for: memoryArchive)
         XCTAssertNotNil(memoryTempURL, "Temporary URL creation for in-memory archive failed.")
 #endif

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
@@ -60,3 +60,36 @@ extension ZIPFoundationTests {
 #endif
     }
 }
+
+extension XCTestCase {
+
+    func XCTAssertSwiftError<T, E: Error & Equatable>(_ expression: @autoclosure () throws -> T,
+                                                      throws error: E,
+                                                      in file: StaticString = #file,
+                                                      line: UInt = #line) {
+        var thrownError: Error?
+        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0}
+        XCTAssertTrue(thrownError is E, "Unexpected error type: \(type(of: thrownError))", file: file, line: line)
+        XCTAssertEqual(thrownError as? E, error, file: file, line: line)
+    }
+
+    func XCTAssertPOSIXError<T>(_ expression: @autoclosure () throws -> T,
+                                throwsErrorWithCode code: POSIXError.Code,
+                                in file: StaticString = #file,
+                                line: UInt = #line) {
+        var thrownError: POSIXError?
+        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? POSIXError }
+        XCTAssertNotNil(thrownError, file: file, line: line)
+        XCTAssertTrue(thrownError?.code == code, file: file, line: line)
+    }
+
+    func XCTAssertCocoaError<T>(_ expression: @autoclosure () throws -> T,
+                                throwsErrorWithCode code: CocoaError.Code,
+                                in file: StaticString = #file,
+                                line: UInt = #line) {
+        var thrownError: CocoaError?
+        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? CocoaError}
+        XCTAssertNotNil(thrownError, file: file, line: line)
+        XCTAssertTrue(thrownError?.code == code, file: file, line: line)
+    }
+}

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests.swift
@@ -74,7 +74,11 @@ extension XCTestCase {
                                 in file: StaticString = #file,
                                 line: UInt = #line) {
         var thrownError: POSIXError?
-        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? POSIXError }
+        XCTAssertThrowsError(try expression(), file: file, line: line) {
+            // This cast is necessary on non-Darwin platforms. Error bridging behaves slightly different there.
+            let nsError = $0 as NSError
+            thrownError = POSIXError(Int32(nsError.code), path: nsError.userInfo[NSFilePathErrorKey] as? String)
+        }
         XCTAssertNotNil(thrownError, file: file, line: line)
         XCTAssertTrue(thrownError?.code == code, file: file, line: line)
     }
@@ -84,7 +88,11 @@ extension XCTestCase {
                                 in file: StaticString = #file,
                                 line: UInt = #line) {
         var thrownError: CocoaError?
-        XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError = $0 as? CocoaError}
+        XCTAssertThrowsError(try expression(), file: file, line: line) {
+            // This cast is necessary on non-Darwin platforms. Error bridging behaves slightly different there.
+            let nsError = $0 as NSError
+            thrownError = CocoaError(CocoaError.Code(rawValue: nsError.code), userInfo: nsError.userInfo)
+        }
         XCTAssertNotNil(thrownError, file: file, line: line)
         XCTAssertTrue(thrownError?.code == code, file: file, line: line)
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
@@ -43,13 +43,8 @@ extension ZIPFoundationTests {
         // Close the file to exercise the error path during readChunk that deals with
         // unreadable file data.
         fclose(file)
-        do {
-            _ = try Data.readChunk(of: 10, from: file)
-        } catch let error as Data.DataError {
-            XCTAssert(error == .unreadableFile)
-        } catch {
-            XCTFail("Unexpected error while testing to read from a closed file.")
-        }
+        XCTAssertSwiftError(try Data.readChunk(of: 10, from: file),
+                            throws: Data.DataError.unreadableFile)
     }
 
     func testWriteChunkErrorConditions() {
@@ -65,14 +60,8 @@ extension ZIPFoundationTests {
         // Close the file to exercise the error path during writeChunk that deals with
         // unwritable files.
         fclose(file)
-        do {
-            let dataWritten = try Data.write(chunk: Data(count: 10), to: file)
-            XCTAssert(dataWritten == 0)
-        } catch let error as Data.DataError {
-            XCTAssert(error == .unwritableFile)
-        } catch {
-            XCTFail("Unexpected error while testing to write into a closed file.")
-        }
+        XCTAssertSwiftError(try Data.write(chunk: Data(count: 10), to: file),
+                            throws: Data.DataError.unreadableFile)
     }
 
     func testCRC32Calculation() {
@@ -120,13 +109,7 @@ extension ZIPFoundationTests {
         // Close the file to exercise the error path during writeChunk that deals with
         // unwritable files.
         fclose(file)
-        do {
-            let dataWritten = try Data.writeLargeChunk(data, size: 1024, bufferSize: 256, to: file)
-            XCTAssert(dataWritten == 0)
-        } catch let error as Data.DataError {
-            XCTAssert(error == .unwritableFile)
-        } catch {
-            XCTFail("Unexpected error while testing to write into a closed file.")
-        }
+        XCTAssertSwiftError(try Data.writeLargeChunk(data, size: 1024, bufferSize: 256, to: file),
+                            throws: Data.DataError.unwritableFile)
     }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationDataSerializationTests.swift
@@ -61,7 +61,7 @@ extension ZIPFoundationTests {
         // unwritable files.
         fclose(file)
         XCTAssertSwiftError(try Data.write(chunk: Data(count: 10), to: file),
-                            throws: Data.DataError.unreadableFile)
+                            throws: Data.DataError.unwritableFile)
     }
 
     func testCRC32Calculation() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests+ZIP64.swift
@@ -15,40 +15,26 @@ extension ZIPFoundationTests {
 
     func testWriteEOCDWithTooLargeSizeOfCentralDirectory() {
         let archive = self.archive(for: #function, mode: .create)
-        var didCatchExpectedError = false
         archive.zip64EndOfCentralDirectory = makeMockZIP64EndOfCentralDirectory(sizeOfCentralDirectory: .max,
                                                                                 numberOfEntries: 0)
-        do {
-            _ = try archive.writeEndOfCentralDirectory(centralDirectoryStructure: makeMockCentralDirectory()!,
-                                                       startOfCentralDirectory: 0,
-                                                       startOfEndOfCentralDirectory: 0,
-                                                       operation: .add)
-        } catch let error as Archive.ArchiveError {
-            XCTAssertNotNil(error == .invalidCentralDirectorySize)
-            didCatchExpectedError = true
-        } catch {
-            XCTFail("Unexpected error while writing end of central directory with large central directory size.")
-        }
-        XCTAssert(didCatchExpectedError)
+        XCTAssertSwiftError(
+            try archive.writeEndOfCentralDirectory(centralDirectoryStructure: makeMockCentralDirectory()!,
+                                                                   startOfCentralDirectory: 0,
+                                                                   startOfEndOfCentralDirectory: 0,
+                                                                   operation: .add),
+                            throws: Archive.ArchiveError.invalidCentralDirectorySize)
     }
 
     func testWriteEOCDWithTooLargeCentralDirectoryOffset() {
         let archive = self.archive(for: #function, mode: .create)
-        var didCatchExpectedError = false
         archive.zip64EndOfCentralDirectory = makeMockZIP64EndOfCentralDirectory(sizeOfCentralDirectory: 0,
                                                                                 numberOfEntries: .max)
-        do {
-            _ = try archive.writeEndOfCentralDirectory(centralDirectoryStructure: makeMockCentralDirectory()!,
-                                                       startOfCentralDirectory: 0,
-                                                       startOfEndOfCentralDirectory: 0,
-                                                       operation: .add)
-        } catch let error as Archive.ArchiveError {
-            XCTAssertNotNil(error == .invalidCentralDirectoryEntryCount)
-            didCatchExpectedError = true
-        } catch {
-            XCTFail("Unexpected error while writing end of central directory with large number of entries.")
-        }
-        XCTAssert(didCatchExpectedError)
+        XCTAssertSwiftError(
+            try archive.writeEndOfCentralDirectory(centralDirectoryStructure: makeMockCentralDirectory()!,
+                                                                   startOfCentralDirectory: 0,
+                                                                   startOfEndOfCentralDirectory: 0,
+                                                                   operation: .add),
+                            throws: Archive.ArchiveError.invalidCentralDirectoryEntryCount)
     }
 
     // MARK: - Helper

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -14,9 +14,7 @@ extension ZIPFoundationTests {
 
     func testArchiveReadErrorConditions() {
         let nonExistantURL = URL(fileURLWithPath: "/nothing")
-        // TODO: enhancement/throwingArchiveInit - throw specific error in `makeBackingConfiguration` and test for that
-        XCTAssertSwiftError(try Archive(url: nonExistantURL, accessMode: .read),
-                               throws: Archive.ArchiveError.unreadableArchive)
+        XCTAssertPOSIXError(try Archive(url: nonExistantURL, accessMode: .update), throwsErrorWithCode: .ENOENT)
         var unreadableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         let processInfo = ProcessInfo.processInfo
         unreadableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
@@ -25,8 +23,7 @@ extension ZIPFoundationTests {
         var result = fileManager.createFile(atPath: unreadableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)
         XCTAssert(result == true)
-        XCTAssertSwiftError(try Archive(url: unreadableArchiveURL, accessMode: .read),
-                               throws: Archive.ArchiveError.unreadableArchive)
+        XCTAssertPOSIXError(try Archive(url: unreadableArchiveURL, accessMode: .update), throwsErrorWithCode: .EACCES)
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
         let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultFilePermissions)]

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -12,24 +12,17 @@ import XCTest
 
 extension ZIPFoundationTests {
 
-    func testArchiveReadErrorConditions() throws {
+    func testArchiveReadErrorConditions() {
         let nonExistantURL = URL(fileURLWithPath: "/nothing")
         XCTAssertPOSIXError(try Archive(url: nonExistantURL, accessMode: .update), throwsErrorWithCode: .ENOENT)
         var unreadableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
-        unreadableArchiveURL.appendPathComponent("nopermission", isDirectory: true)
-        let fileManager = FileManager()
-        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
-        try fileManager.createDirectory(at: unreadableArchiveURL, withIntermediateDirectories: true)
         let processInfo = ProcessInfo.processInfo
         unreadableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
+        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
+        let fileManager = FileManager()
         var result = fileManager.createFile(atPath: unreadableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)
         XCTAssert(result == true)
-        // On non-Darwin systems, `fopen` can succeed even if a file has no permissions but the directory
-        // permissions are sufficient. To ensure the same behavior as on Darwin platforms, we also set
-        // restrictive directory permissions here.
-        try fileManager.setAttributes(noPermissionAttributes,
-                                      ofItemAtPath: unreadableArchiveURL.deletingLastPathComponent().path)
         XCTAssertPOSIXError(try Archive(url: unreadableArchiveURL, accessMode: .update), throwsErrorWithCode: .EACCES)
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -30,10 +30,8 @@ extension ZIPFoundationTests {
         result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                         attributes: fullPermissionAttributes)
         XCTAssert(result == true)
-        // TODO: enhancement/throwingArchiveInit - throw specific error in `makeBackingConfiguration` and test for that
-        let noEndOfCentralDirectoryArchive = try? Archive(url: noEndOfCentralDirectoryArchiveURL,
-                                                     accessMode: .read)
-        XCTAssertNil(noEndOfCentralDirectoryArchive)
+        XCTAssertSwiftError(try Archive(url: noEndOfCentralDirectoryArchiveURL, accessMode: .read),
+                            throws: Archive.ArchiveError.missingEndOfCentralDirectoryRecord)
     }
 
     func testArchiveIteratorErrorConditions() throws {

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -14,8 +14,9 @@ extension ZIPFoundationTests {
 
     func testArchiveReadErrorConditions() {
         let nonExistantURL = URL(fileURLWithPath: "/nothing")
-        let nonExistantArchive = Archive(url: nonExistantURL, accessMode: .read)
-        XCTAssertNil(nonExistantArchive)
+        // TODO: enhancement/throwingArchiveInit - throw specific error in `makeBackingConfiguration` and test for that
+        XCTAssertSwiftError(try Archive(url: nonExistantURL, accessMode: .read),
+                               throws: Archive.ArchiveError.unreadableArchive)
         var unreadableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         let processInfo = ProcessInfo.processInfo
         unreadableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
@@ -24,15 +25,16 @@ extension ZIPFoundationTests {
         var result = fileManager.createFile(atPath: unreadableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)
         XCTAssert(result == true)
-        let unreadableArchive = Archive(url: unreadableArchiveURL, accessMode: .read)
-        XCTAssertNil(unreadableArchive)
+        XCTAssertSwiftError(try Archive(url: unreadableArchiveURL, accessMode: .read),
+                               throws: Archive.ArchiveError.unreadableArchive)
         var noEndOfCentralDirectoryArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
         noEndOfCentralDirectoryArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
         let fullPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: defaultFilePermissions)]
         result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                         attributes: fullPermissionAttributes)
         XCTAssert(result == true)
-        let noEndOfCentralDirectoryArchive = Archive(url: noEndOfCentralDirectoryArchiveURL,
+        // TODO: enhancement/throwingArchiveInit - throw specific error in `makeBackingConfiguration` and test for that
+        let noEndOfCentralDirectoryArchive = try? Archive(url: noEndOfCentralDirectoryArchiveURL,
                                                      accessMode: .read)
         XCTAssertNil(noEndOfCentralDirectoryArchive)
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -36,7 +36,7 @@ extension ZIPFoundationTests {
         XCTAssertNil(noEndOfCentralDirectoryArchive)
     }
 
-    func testArchiveIteratorErrorConditions() {
+    func testArchiveIteratorErrorConditions() throws {
         var didFailToMakeIteratorAsExpected = true
         // Construct an archive that only contains an EndOfCentralDirectoryRecord
         // with a number of entries > 0.
@@ -54,11 +54,8 @@ extension ZIPFoundationTests {
                                             contents: invalidCentralDirECDSData,
                                             attributes: nil)
         XCTAssert(result == true)
-        guard let invalidCentralDirArchive = Archive(url: invalidCentralDirArchiveURL,
-                                                     accessMode: .read) else {
-            XCTFail("Failed to read archive.")
-            return
-        }
+        let invalidCentralDirArchive = try Archive(url: invalidCentralDirArchiveURL,
+                                                   accessMode: .read)
         for _ in invalidCentralDirArchive {
             didFailToMakeIteratorAsExpected = false
         }
@@ -73,11 +70,8 @@ extension ZIPFoundationTests {
             // should fail.
             invalidLocalFHArchiveData[26] = 0xFF
             try invalidLocalFHArchiveData.write(to: invalidLocalFHArchiveURL)
-            guard let invalidLocalFHArchive = Archive(url: invalidLocalFHArchiveURL,
-                                                      accessMode: .read) else {
-                XCTFail("Failed to read local file header.")
-                return
-            }
+            let invalidLocalFHArchive = try Archive(url: invalidLocalFHArchiveURL,
+                                                    accessMode: .read)
             for _ in invalidLocalFHArchive {
                 didFailToMakeIteratorAsExpected = false
             }

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -26,7 +26,7 @@ extension ZIPFoundationTests {
         XCTAssert(result == true)
         XCTAssertSwiftError(try Archive(url: noEndOfCentralDirectoryArchiveURL, accessMode: .read),
                             throws: Archive.ArchiveError.missingEndOfCentralDirectoryRecord)
-        self.runWithUnprivilegedUser {
+        self.runWithUnprivilegedGroup {
             var unreadableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
             unreadableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
             let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
@@ -135,15 +135,12 @@ extension ZIPFoundationTests {
         guard let nonFileURL = URL(string: "https://www.peakstep.com/") else {
             XCTFail("Failed to create file URL."); return
         }
+
+        XCTAssertCocoaError(_ = try FileManager.fileModificationDateTimeForItem(at: nonFileURL),
+                            throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        do {
-            _ = try FileManager.fileModificationDateTimeForItem(at: nonFileURL)
-            _ = try FileManager.fileModificationDateTimeForItem(at: nonExistantURL)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileReadNoSuchFile)
-        } catch {
-            XCTFail("Unexpected error while trying to retrieve file modification date")
-        }
+        XCTAssertCocoaError(_ = try FileManager.fileModificationDateTimeForItem(at: nonExistantURL),
+                            throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         let msDOSDate = Date(timeIntervalSince1970: TimeInterval(Int.min)).fileModificationDate
         XCTAssert(msDOSDate == 0)
         let msDOSTime = Date(timeIntervalSince1970: TimeInterval(Int.min)).fileModificationTime
@@ -156,32 +153,20 @@ extension ZIPFoundationTests {
 
     func testFileSizeHelperMethods() {
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        do {
-            _ = try FileManager.fileSizeForItem(at: nonExistantURL)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileReadNoSuchFile)
-        } catch { XCTFail("Unexpected error while trying to retrieve file size") }
+        XCTAssertCocoaError(_ = try FileManager.fileSizeForItem(at: nonExistantURL),
+                            throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
     }
 
     func testFileTypeHelperMethods() {
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        do {
-            _ = try FileManager.typeForItem(at: nonExistantURL)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileReadNoSuchFile)
-        } catch {
-            XCTFail("Unexpected error while trying to retrieve file type")
-        }
+        XCTAssertCocoaError(_ = try FileManager.typeForItem(at: nonExistantURL),
+                            throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         guard let nonFileURL = URL(string: "https://www.peakstep.com") else {
             XCTFail("Failed to create test URL."); return
         }
-        do {
-            _ = try FileManager.typeForItem(at: nonFileURL)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileReadNoSuchFile)
-        } catch {
-            XCTFail("Unexpected error while trying to retrieve file type")
-        }
+
+        XCTAssertCocoaError(_ = try FileManager.typeForItem(at: nonFileURL),
+                            throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
     }
 
     func testFileModificationDate() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
@@ -136,10 +136,10 @@ extension ZIPFoundationTests {
             XCTFail("Failed to create file URL."); return
         }
 
-        XCTAssertCocoaError(_ = try FileManager.fileModificationDateTimeForItem(at: nonFileURL),
+        XCTAssertCocoaError(try FileManager.fileModificationDateTimeForItem(at: nonFileURL),
                             throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        XCTAssertCocoaError(_ = try FileManager.fileModificationDateTimeForItem(at: nonExistantURL),
+        XCTAssertCocoaError(try FileManager.fileModificationDateTimeForItem(at: nonExistantURL),
                             throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         let msDOSDate = Date(timeIntervalSince1970: TimeInterval(Int.min)).fileModificationDate
         XCTAssert(msDOSDate == 0)
@@ -153,19 +153,19 @@ extension ZIPFoundationTests {
 
     func testFileSizeHelperMethods() {
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        XCTAssertCocoaError(_ = try FileManager.fileSizeForItem(at: nonExistantURL),
+        XCTAssertCocoaError(try FileManager.fileSizeForItem(at: nonExistantURL),
                             throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
     }
 
     func testFileTypeHelperMethods() {
         let nonExistantURL = URL(fileURLWithPath: "/nonexistant")
-        XCTAssertCocoaError(_ = try FileManager.typeForItem(at: nonExistantURL),
+        XCTAssertCocoaError(try FileManager.typeForItem(at: nonExistantURL),
                             throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
         guard let nonFileURL = URL(string: "https://www.peakstep.com") else {
             XCTFail("Failed to create test URL."); return
         }
 
-        XCTAssertCocoaError(_ = try FileManager.typeForItem(at: nonFileURL),
+        XCTAssertCocoaError(try FileManager.typeForItem(at: nonFileURL),
                             throwsErrorWithCode: CocoaError.fileReadNoSuchFile)
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
@@ -113,9 +113,7 @@ extension ZIPFoundationTests {
         } catch {
             throw ZIP64FileManagerTestsError.failedToZipItem(url: assetURL)
         }
-        guard let archive = Archive(url: fileArchiveURL, accessMode: .read) else {
-            throw ZIP64FileManagerTestsError.failedToZipItem(url: fileArchiveURL)
-        }
+        let archive = try Archive(url: fileArchiveURL, accessMode: .read)
         XCTAssertNotNil(archive[assetURL.lastPathComponent])
         XCTAssert(archive.checkIntegrity())
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -125,7 +125,7 @@ extension ZIPFoundationTests {
         let archive = self.archive(for: #function, mode: .read, preferredEncoding: encoding)
         let destinationURL = self.createDirectory(for: #function)
         do {
-            try fileManager.unzipItem(at: archive.url, to: destinationURL, preferredEncoding: encoding)
+            try fileManager.unzipItem(at: archive.url, to: destinationURL, pathEncoding: encoding)
         } catch {
             XCTFail("Failed to extract item."); return
         }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 extension ZIPFoundationTests {
 
-    func testZipItem() {
+    func testZipItem() throws {
         let fileManager = FileManager()
         let assetURL = self.resourceURL(for: #function, pathExtension: "png")
         var fileArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
@@ -21,9 +21,7 @@ extension ZIPFoundationTests {
         do {
             try fileManager.zipItem(at: assetURL, to: fileArchiveURL)
         } catch { XCTFail("Failed to zip item at URL:\(assetURL)") }
-        guard let archive = Archive(url: fileArchiveURL, accessMode: .read) else {
-            XCTFail("Failed to read archive."); return
-        }
+        let archive = try Archive(url: fileArchiveURL, accessMode: .read)
         XCTAssertNotNil(archive[assetURL.lastPathComponent])
         XCTAssert(archive.checkIntegrity())
         var directoryURL = ZIPFoundationTests.tempZipDirectoryURL
@@ -49,13 +47,9 @@ extension ZIPFoundationTests {
             try fileManager.zipItem(at: directoryURL, to: parentDirectoryArchiveURL, shouldKeepParent: false)
             try fileManager.zipItem(at: directoryURL, to: compressedDirectoryArchiveURL, compressionMethod: .deflate)
         } catch { XCTFail("Unexpected error while trying to zip via fileManager.") }
-        guard let directoryArchive = Archive(url: directoryArchiveURL, accessMode: .read) else {
-            XCTFail("Failed to read archive."); return
-        }
+        let directoryArchive = try Archive(url: directoryArchiveURL, accessMode: .read)
         XCTAssert(directoryArchive.checkIntegrity())
-        guard let parentDirectoryArchive = Archive(url: parentDirectoryArchiveURL, accessMode: .read) else {
-            XCTFail("Failed to read archive."); return
-        }
+        let parentDirectoryArchive = try Archive(url: parentDirectoryArchiveURL, accessMode: .read)
         XCTAssert(parentDirectoryArchive.checkIntegrity())
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -151,7 +151,7 @@ extension ZIPFoundationTests {
             try fileManager.unzipItem(at: nonZipArchiveURL, to: destinationURL)
             XCTFail("Error when trying to unzip non-archive not raised")
         } catch let error as Archive.ArchiveError {
-            XCTAssertTrue(error == .unreadableArchive)
+            XCTAssertTrue(error == .missingEndOfCentralDirectoryRecord)
         } catch { XCTFail("Unexpected error while trying to unzip via fileManager."); return }
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
@@ -224,14 +224,14 @@ extension ZIPFoundationTests {
 
 extension ZIPFoundationTests {
     func memoryArchive(for testFunction: String, mode: Archive.AccessMode,
-                       preferredEncoding: String.Encoding? = nil) -> Archive {
+                       pathEncoding: String.Encoding? = nil) -> Archive {
         var sourceArchiveURL = ZIPFoundationTests.resourceDirectoryURL
         sourceArchiveURL.appendPathComponent(testFunction.replacingOccurrences(of: "()", with: ""))
         sourceArchiveURL.appendPathExtension("zip")
         do {
             let data = mode == .create ? Data() : try Data(contentsOf: sourceArchiveURL)
             guard let archive = Archive(data: data, accessMode: mode,
-                                        preferredEncoding: preferredEncoding) else {
+                                        pathEncoding: pathEncoding) else {
                                             throw Archive.ArchiveError.unreadableArchive
             }
             return archive

--- a/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
@@ -96,7 +96,7 @@ extension ZIPFoundationTests {
         XCTAssert(archive.checkIntegrity())
     }
 
-    func testUpdateArchiveRemoveUncompressedEntryFromMemory() {
+    func testUpdateArchiveRemoveUncompressedEntryFromMemory() throws {
         let archive = self.memoryArchive(for: #function, mode: .update)
         XCTAssert(archive.checkIntegrity())
         guard let entryToRemove = archive["original"] else {
@@ -120,18 +120,15 @@ extension ZIPFoundationTests {
             }
         }
         XCTAssert(didCatchExpectedError)
-        let emptyArchive = Archive(accessMode: .create)
         let data = Data.makeRandomData(size: 1024)
-        guard let replacementArchive = Archive(data: data, accessMode: .create) else {
-            XCTFail("Failed to create replacement archive.")
-            return
-        }
+        let emptyArchive = try Archive(accessMode: .create)
+        let replacementArchive = try Archive(data: data, accessMode: .create)
         didCatchExpectedError = false
         // Trigger the error code path that is taken when no temporary archive
         // can be created during replacement
         replacementArchive.memoryFile = nil
         do {
-            try emptyArchive?.replaceCurrentArchive(with: replacementArchive)
+            try emptyArchive.replaceCurrentArchive(with: replacementArchive)
         } catch {
             didCatchExpectedError = true
         }
@@ -139,10 +136,10 @@ extension ZIPFoundationTests {
         #endif
     }
 
-    func testMemoryArchiveErrorConditions() {
+    func testMemoryArchiveErrorConditions() throws {
         let data = Data.makeRandomData(size: 1024)
-        let invalidArchive = Archive(data: data, accessMode: .read)
-        XCTAssertNil(invalidArchive)
+        XCTAssertSwiftError(try Archive(data: data, accessMode: .read),
+                            throws: Archive.ArchiveError.missingEndOfCentralDirectoryRecord)
         // Trigger the code path that is taken if funopen() fails
         // We can only do this on Apple platforms
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -223,6 +220,7 @@ extension ZIPFoundationTests {
 // MARK: - Helpers
 
 extension ZIPFoundationTests {
+
     func memoryArchive(for testFunction: String, mode: Archive.AccessMode,
                        pathEncoding: String.Encoding? = nil) -> Archive {
         var sourceArchiveURL = ZIPFoundationTests.resourceDirectoryURL
@@ -230,10 +228,8 @@ extension ZIPFoundationTests {
         sourceArchiveURL.appendPathExtension("zip")
         do {
             let data = mode == .create ? Data() : try Data(contentsOf: sourceArchiveURL)
-            guard let archive = Archive(data: data, accessMode: mode,
-                                        pathEncoding: pathEncoding) else {
-                                            throw Archive.ArchiveError.unreadableArchive
-            }
+            let archive = try Archive(data: data, accessMode: mode,
+                                  pathEncoding: pathEncoding)
             return archive
         } catch {
             XCTFail("Failed to open memory archive for '\(sourceArchiveURL.lastPathComponent)'")

--- a/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
@@ -143,11 +143,13 @@ extension ZIPFoundationTests {
         // Trigger the code path that is taken if funopen() fails
         // We can only do this on Apple platforms
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        var unallocatableArchive: Archive?
-        self.runWithoutMemory {
-            unallocatableArchive = Archive(data: data, accessMode: .read)
+        let archiveCreation = {
+            self.XCTAssertSwiftError(try Archive(data: data, accessMode: .read),
+                                throws: Archive.ArchiveError.unreadableArchive)
         }
-        XCTAssertNil(unallocatableArchive)
+        self.runWithoutMemory {
+            try? archiveCreation()
+        }
         #endif
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
@@ -111,7 +111,7 @@ extension ZIPFoundationTests {
         }
     }
 
-    func testZipItemProgress() {
+    func testZipItemProgress() throws {
         let fileManager = FileManager()
         let assetURL = self.resourceURL(for: #function, pathExtension: "png")
         var fileArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
@@ -148,12 +148,10 @@ extension ZIPFoundationTests {
             } catch { didSucceed = false }
         }
         self.wait(for: [fileExpectation, directoryExpectation], timeout: 20.0)
-        guard let archive = Archive(url: fileArchiveURL, accessMode: .read),
-              let directoryArchive = Archive(url: directoryArchiveURL, accessMode: .read) else {
-            XCTFail("Failed to read archive.") ; return
-        }
         XCTAssert(didSucceed)
+        let archive = try Archive(url: fileArchiveURL, accessMode: .read)
         XCTAssert(archive.checkIntegrity())
+        let directoryArchive = try Archive(url: directoryArchiveURL, accessMode: .read)
         XCTAssert(directoryArchive.checkIntegrity())
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -151,7 +151,7 @@ extension ZIPFoundationTests {
         }
     }
 
-    func testCorruptFileErrorConditions() {
+    func testCorruptFileErrorConditions() throws {
         let archiveURL = self.resourceURL(for: #function, pathExtension: "zip")
         let fileManager = FileManager()
         let destinationFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: archiveURL.path)
@@ -163,10 +163,7 @@ extension ZIPFoundationTests {
             // detects the failure when reading the stream
             _ = try Data.write(chunk: Data(count: 512*1024), to: destinationFile)
             fclose(destinationFile)
-            guard let archive = Archive(url: archiveURL, accessMode: .read) else {
-                XCTFail("Failed to read archive.")
-                return
-            }
+            let archive = try Archive(url: archiveURL, accessMode: .read)
             guard let entry = archive["data.random"] else {
                 XCTFail("Failed to read entry.")
                 return

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -117,14 +117,8 @@ extension ZIPFoundationTests {
             return
         }
         XCTAssertNotNil(fileEntry)
-        do {
-            _ = try archive.extract(fileEntry, to: archive.url)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileWriteFileExists)
-        } catch {
-            XCTFail("Unexpected error while trying to extract entry to existing URL.")
-            return
-        }
+        XCTAssertCocoaError(_ = try archive.extract(fileEntry, to: archive.url),
+                            throwsErrorWithCode: .fileWriteFileExists)
         guard let linkEntry = archive["testZipItemLink"] else {
             XCTFail("Failed to obtain test asset from archive.")
             return
@@ -141,14 +135,8 @@ extension ZIPFoundationTests {
             return
         }
         XCTAssertNotNil(linkEntry)
-        do {
-            _ = try archive.extract(linkEntry, to: archive.url)
-        } catch let error as CocoaError {
-            XCTAssert(error.code == CocoaError.fileWriteFileExists)
-        } catch {
-            XCTFail("Unexpected error while trying to extract link entry to existing URL.")
-            return
-        }
+        XCTAssertCocoaError(_ = try archive.extract(linkEntry, to: archive.url),
+                            throwsErrorWithCode: .fileWriteFileExists)
     }
 
     func testCorruptFileErrorConditions() throws {

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -164,7 +164,6 @@ extension ZIPFoundationTests {
         }
     }
 
-
     func testInvalidCompressionMethodErrorConditions() {
         let archive = self.archive(for: #function, mode: .read)
         guard let entry = archive[".DS_Store"] else {
@@ -281,6 +280,7 @@ extension ZIPFoundationTests {
         let fileManager = FileManager()
         let archive = self.archive(for: #function, mode: .read)
         let destinationURL = self.createDirectory(for: #function)
-        XCTAssertCocoaError(try fileManager.unzipItem(at: archive.url, to: destinationURL), throwsErrorWithCode: .fileReadInvalidFileName)
+        XCTAssertCocoaError(try fileManager.unzipItem(at: archive.url, to: destinationURL),
+                            throwsErrorWithCode: .fileReadInvalidFileName)
     }
 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -273,7 +273,6 @@ extension ZIPFoundationTests {
         let destinationURL = self.createDirectory(for: #function)
         XCTAssertSwiftError(try fileManager.unzipItem(at: archive.url, to: destinationURL),
                             throws: Archive.ArchiveError.invalidCRC32)
-        XCTFail("Extraction should fail")
     }
 
     func testTraversalAttack() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -117,7 +117,7 @@ extension ZIPFoundationTests {
             return
         }
         XCTAssertNotNil(fileEntry)
-        XCTAssertCocoaError(_ = try archive.extract(fileEntry, to: archive.url),
+        XCTAssertCocoaError(try archive.extract(fileEntry, to: archive.url),
                             throwsErrorWithCode: .fileWriteFileExists)
         guard let linkEntry = archive["testZipItemLink"] else {
             XCTFail("Failed to obtain test asset from archive.")
@@ -135,7 +135,7 @@ extension ZIPFoundationTests {
             return
         }
         XCTAssertNotNil(linkEntry)
-        XCTAssertCocoaError(_ = try archive.extract(linkEntry, to: archive.url),
+        XCTAssertCocoaError(try archive.extract(linkEntry, to: archive.url),
                             throwsErrorWithCode: .fileWriteFileExists)
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -80,17 +80,11 @@ class ZIPFoundationTests: XCTestCase {
                 let fileManager = FileManager()
                 try fileManager.copyItem(at: sourceArchiveURL, to: destinationArchiveURL)
             }
-            guard let archive = Archive(url: destinationArchiveURL, accessMode: mode,
-                                        preferredEncoding: preferredEncoding) else {
-                throw Archive.ArchiveError.unreadableArchive
-            }
+            let archive = try Archive(url: destinationArchiveURL, accessMode: mode,
+                                      pathEncoding: preferredEncoding)
             return archive
-        } catch Archive.ArchiveError.unreadableArchive {
-            XCTFail("Failed to get test archive '\(destinationArchiveURL.lastPathComponent)'")
-            type(of: self).tearDown()
-            preconditionFailure()
         } catch {
-            XCTFail("File system error: \(error)")
+            XCTFail("Failed to get test archive: \(error)")
             type(of: self).tearDown()
             preconditionFailure()
         }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -130,18 +130,13 @@ class ZIPFoundationTests: XCTestCase {
         return URL
     }
 
-    func runWithUnprivilegedUser(handler: () throws -> Void) {
-        let originalUID = getuid()
+    func runWithUnprivilegedGroup(handler: () throws -> Void) {
         let originalGID = getgid()
-        defer {
-            setgid(originalGID)
-            setuid(originalUID)
-        }
+        defer { setgid(originalGID) }
         guard let user = getpwnam("nobody") else { return }
 
         let gid = user.pointee.pw_gid
-        let uid = user.pointee.pw_uid
-        guard 0 == setgid(gid), 0 == setuid(uid) else { return }
+        guard 0 == setgid(gid) else { return }
     }
 
     func runWithFileDescriptorLimit(_ limit: UInt64, handler: () throws -> Void) rethrows {

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -136,7 +136,7 @@ class ZIPFoundationTests: XCTestCase {
         return URL
     }
 
-    func runWithFileDescriptorLimit(_ limit: UInt64, handler: () -> Void) {
+    func runWithFileDescriptorLimit(_ limit: UInt64, handler: () throws -> Void) rethrows {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
         let fileNoFlag = RLIMIT_NOFILE
         #else
@@ -148,7 +148,7 @@ class ZIPFoundationTests: XCTestCase {
         tempRlimit.rlim_cur = rlim_t(limit)
         setrlimit(fileNoFlag, &tempRlimit)
         defer { setrlimit(fileNoFlag, &storedRlimit) }
-        handler()
+        try handler()
     }
 
     func runWithoutMemory(handler: () -> Void) {

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -121,18 +121,12 @@ extension ZIPFoundationTests {
     }
 
     func testArchiveAddEntryErrorConditions() {
-        var didCatchExpectedError = false
         let readonlyArchive = self.archive(for: #function, mode: .read)
-        do {
-            try readonlyArchive.addEntry(with: "Test", type: .directory,
-                                         uncompressedSize: Int64(0), provider: { _, _ in return Data()})
-        } catch let error as Archive.ArchiveError {
-            XCTAssert(error == .unwritableArchive)
-            didCatchExpectedError = true
-        } catch {
-            XCTFail("Unexpected error while trying to add an entry to a readonly archive.")
-        }
-        XCTAssertTrue(didCatchExpectedError)
+        XCTAssertSwiftError(try readonlyArchive.addEntry(with: "Test",
+                                                         type: .directory,
+                                                         uncompressedSize: Int64(0),
+                                                         provider: { _, _ in return Data() }),
+                            throws: Archive.ArchiveError.unwritableArchive)
     }
 
     func testCreateArchiveAddZeroSizeUncompressedEntry() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -286,15 +286,18 @@ extension ZIPFoundationTests {
     }
 
     func testArchiveUpdateErrorConditions() {
-        var nonUpdatableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
-        let processInfo = ProcessInfo.processInfo
-        nonUpdatableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
-        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
-        let fileManager = FileManager()
-        let result = fileManager.createFile(atPath: nonUpdatableArchiveURL.path, contents: nil,
-                                            attributes: noPermissionAttributes)
-        XCTAssert(result == true)
-        XCTAssertPOSIXError(try Archive(url: nonUpdatableArchiveURL, accessMode: .update), throwsErrorWithCode: .EACCES)
+        self.runWithUnprivilegedUser {
+            var nonUpdatableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
+            let processInfo = ProcessInfo.processInfo
+            nonUpdatableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
+            let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
+            let fileManager = FileManager()
+            let result = fileManager.createFile(atPath: nonUpdatableArchiveURL.path, contents: nil,
+                                                attributes: noPermissionAttributes)
+            XCTAssert(result == true)
+            XCTAssertPOSIXError(try Archive(url: nonUpdatableArchiveURL, accessMode: .update),
+                                throwsErrorWithCode: .EACCES)
+        }
     }
 
     func testReplaceCurrentArchiveWithArchiveCrossLink() {

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -305,8 +305,7 @@ extension ZIPFoundationTests {
         let result = fileManager.createFile(atPath: nonUpdatableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)
         XCTAssert(result == true)
-        XCTAssertSwiftError(try Archive(url: nonUpdatableArchiveURL, accessMode: .update),
-                            throws: Archive.ArchiveError.unwritableArchive)
+        XCTAssertPOSIXError(try Archive(url: nonUpdatableArchiveURL, accessMode: .update), throwsErrorWithCode: .EACCES)
     }
 
     func testReplaceCurrentArchiveWithArchiveCrossLink() {
@@ -325,8 +324,9 @@ extension ZIPFoundationTests {
                 }
                 let vol2URL = URL(fileURLWithPath: "/Volumes/\(volName)")
                 defer {
+                    let options: FileManager.UnmountOptions = [.allPartitionsAndEjectDisk, .withoutUI]
                     FileManager.default.unmountVolume(at: vol2URL, options:
-                                                        [.allPartitionsAndEjectDisk, .withoutUI], completionHandler: { (error) in
+                                                        options, completionHandler: { (error) in
                         guard error == nil else {
                             XCTFail("\(String(describing: error))")
                             return

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -286,7 +286,7 @@ extension ZIPFoundationTests {
     }
 
     func testArchiveUpdateErrorConditions() {
-        self.runWithUnprivilegedUser {
+        self.runWithUnprivilegedGroup {
             var nonUpdatableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
             let processInfo = ProcessInfo.processInfo
             nonUpdatableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -285,22 +285,15 @@ extension ZIPFoundationTests {
                             throws: Archive.ArchiveError.missingEndOfCentralDirectoryRecord)
     }
 
-    func testArchiveUpdateErrorConditions() throws {
+    func testArchiveUpdateErrorConditions() {
         var nonUpdatableArchiveURL = ZIPFoundationTests.tempZipDirectoryURL
-        nonUpdatableArchiveURL.appendPathComponent("nopermission", isDirectory: true)
-        let fileManager = FileManager()
-        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
-        try fileManager.createDirectory(at: nonUpdatableArchiveURL, withIntermediateDirectories: true)
         let processInfo = ProcessInfo.processInfo
         nonUpdatableArchiveURL.appendPathComponent(processInfo.globallyUniqueString)
+        let noPermissionAttributes = [FileAttributeKey.posixPermissions: NSNumber(value: Int16(0o000))]
+        let fileManager = FileManager()
         let result = fileManager.createFile(atPath: nonUpdatableArchiveURL.path, contents: nil,
                                             attributes: noPermissionAttributes)
         XCTAssert(result == true)
-        // On non-Darwin systems, `fopen` can succeed even if a file has no permissions but the directory
-        // permissions are sufficient. To ensure the same behavior as on Darwin platforms, we also set
-        // restrictive directory permissions here.
-        try fileManager.setAttributes(noPermissionAttributes,
-                                      ofItemAtPath: nonUpdatableArchiveURL.deletingLastPathComponent().path)
         XCTAssertPOSIXError(try Archive(url: nonUpdatableArchiveURL, accessMode: .update), throwsErrorWithCode: .EACCES)
     }
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -336,16 +336,12 @@ extension ZIPFoundationTests {
                 }
                 let vol1ArchiveURL = tempDir.appendingPathComponent("vol1Archive")
                 let vol2ArchiveURL = vol2URL.appendingPathComponent("vol2Archive")
-                guard let vol1Archive = Archive(url: vol1ArchiveURL, accessMode: .create),
-                      let vol2Archive = Archive(url: vol2ArchiveURL, accessMode: .create) else {
-                    XCTFail("Failed to create test archive '\(vol2ArchiveURL)'")
-                    type(of: self).tearDown()
-                    return
-                }
-
                 do {
+                    let vol1Archive = try Archive(url: vol1ArchiveURL, accessMode: .create)
+                    let vol2Archive = try Archive(url: vol2ArchiveURL, accessMode: .create)
                     try vol1Archive.replaceCurrentArchive(with: vol2Archive)
                 } catch {
+                    type(of: self).tearDown()
                     XCTFail("\(String(describing: error))")
                     return
                 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -290,10 +290,8 @@ extension ZIPFoundationTests {
         let result = fileManager.createFile(atPath: noEndOfCentralDirectoryArchiveURL.path, contents: nil,
                                             attributes: fullPermissionAttributes)
         XCTAssert(result == true)
-        // TODO: enhancement/throwingArchiveInit - throw specific error in `makeBackingConfiguration` and test for that
-        let noEndOfCentralDirectoryArchive = try? Archive(url: noEndOfCentralDirectoryArchiveURL,
-                                                          accessMode: .update)
-        XCTAssertNil(noEndOfCentralDirectoryArchive)
+        XCTAssertSwiftError(try Archive(url: noEndOfCentralDirectoryArchiveURL, accessMode: .update),
+                            throws: Archive.ArchiveError.missingEndOfCentralDirectoryRecord)
     }
 
     func testArchiveUpdateErrorConditions() {

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		BA58FB162951F49400892CE7 /* Date+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA58FB152951F49400892CE7 /* Date+ZIP.swift */; };
 		BA643D7A264811FB00018273 /* URL+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA643D79264811FB00018273 /* URL+ZIP.swift */; };
 		BA643D7C2648131C00018273 /* Archive+Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA643D7B2648131C00018273 /* Archive+Progress.swift */; };
+		BA85B4F2299160E4003F2748 /* Archive+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F1299160E4003F2748 /* Archive+Deprecated.swift */; };
+		BA85B4F42991614E003F2748 /* FileManager+ZIPDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */; };
 		BAAF13DA25CC140300070A95 /* ZIPFoundationErrorConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAF13D925CC140300070A95 /* ZIPFoundationErrorConditionTests.swift */; };
 		BACE20B826F7CE6C003BA312 /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */; };
 		BACE20BA26F7D18A003BA312 /* Archive+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20B926F7D18A003BA312 /* Archive+Helpers.swift */; };
@@ -77,6 +79,8 @@
 		BA58FB152951F49400892CE7 /* Date+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ZIP.swift"; sourceTree = "<group>"; };
 		BA643D79264811FB00018273 /* URL+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+ZIP.swift"; sourceTree = "<group>"; };
 		BA643D7B2648131C00018273 /* Archive+Progress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Progress.swift"; sourceTree = "<group>"; };
+		BA85B4F1299160E4003F2748 /* Archive+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Deprecated.swift"; sourceTree = "<group>"; };
+		BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIPDeprecated.swift"; sourceTree = "<group>"; };
 		BAAF13D925CC140300070A95 /* ZIPFoundationErrorConditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationErrorConditionTests.swift; sourceTree = "<group>"; };
 		BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+BackingConfiguration.swift"; sourceTree = "<group>"; };
 		BACE20B926F7D18A003BA312 /* Archive+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Helpers.swift"; sourceTree = "<group>"; };
@@ -185,6 +189,7 @@
 			children = (
 				OBJ_11 /* Archive.swift */,
 				BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */,
+				BA85B4F1299160E4003F2748 /* Archive+Deprecated.swift */,
 				BACE20B926F7D18A003BA312 /* Archive+Helpers.swift */,
 				95B5A3D32366731B00D4D8FD /* Archive+MemoryFile.swift */,
 				BA643D7B2648131C00018273 /* Archive+Progress.swift */,
@@ -201,6 +206,7 @@
 				BACE20BC26F7D545003BA312 /* Entry+Serialization.swift */,
 				590A7DA726B0F91E00CBEFB4 /* Entry+ZIP64.swift */,
 				OBJ_15 /* FileManager+ZIP.swift */,
+				BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */,
 				BA643D79264811FB00018273 /* URL+ZIP.swift */,
 			);
 			name = ZIPFoundation;
@@ -326,6 +332,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_48 /* Archive+Reading.swift in Sources */,
+				BA85B4F2299160E4003F2748 /* Archive+Deprecated.swift in Sources */,
 				BA0CE5062746AF1A004D8DD4 /* Data+CompressionDeprecated.swift in Sources */,
 				OBJ_49 /* Archive+Writing.swift in Sources */,
 				OBJ_50 /* Archive.swift in Sources */,
@@ -335,6 +342,7 @@
 				OBJ_52 /* Data+Serialization.swift in Sources */,
 				590A7DA826B0F91F00CBEFB4 /* Entry+ZIP64.swift in Sources */,
 				BACE20BA26F7D18A003BA312 /* Archive+Helpers.swift in Sources */,
+				BA85B4F42991614E003F2748 /* FileManager+ZIPDeprecated.swift in Sources */,
 				590A7DA626B0F8F800CBEFB4 /* Archive+ZIP64.swift in Sources */,
 				BA643D7A264811FB00018273 /* URL+ZIP.swift in Sources */,
 				BA58FB162951F49400892CE7 /* Date+ZIP.swift in Sources */,


### PR DESCRIPTION
Fixes #126
Fixes #242

# Changes proposed in this PR
* Makes `Archive` initializers throwing
*  Adds early-exit codepath when encountering non-ZIP files