### PR TITLE
Change library type to dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
         .macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
-        .library(name: "ZIPFoundation", targets: ["ZIPFoundation"]),
-        .library(name: "ZIPFoundationDynamic", type: .dynamic, targets: ["ZIPFoundation"])
+        .library(name: "ZIPFoundation", type: .dynamic, targets: ["ZIPFoundation"]),
     ],
     targets: targets,
     swiftLanguageVersions: [.v4, .v4_2, .v5]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
-        .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])
+        .library(name: "ZIPFoundation", targets: ["ZIPFoundation"]),
+        .library(name: "ZIPFoundationDynamic", type: .dynamic, targets: ["ZIPFoundation"])
     ],
     targets: targets,
     swiftLanguageVersions: [.v4, .v4_2, .v5]


### PR DESCRIPTION
Hi, I would like to add the possibility to import the library with dynamic link type. I have a XCFramework which has the ZIPFoundation as its dependency, however I am not able to link the ZIPFoundation because SPM imports it as static library so at runtime my app crashes because  dyld Symbol for ZIPFoundation was not found.

# Changes proposed in this PR
* Change library type to dynamic


