### PR TITLE
Allow writing of entry when full uncompressed size is not known.

### DIFF
--- a/Sources/ZIPFoundation/Archive+Helpers.swift
+++ b/Sources/ZIPFoundation/Archive+Helpers.swift
@@ -57,6 +57,7 @@ extension Archive {
                 (sizeWritten, checksum) = try self.writeUncompressed(size: uncompressedSize,
                                                                      bufferSize: bufferSize,
                                                                      progress: progress, provider: provider)
+                totalRead = sizeWritten
             case .deflate:
                 (totalRead, sizeWritten, checksum) = try self.writeCompressed(size: uncompressedSize,
                                                                    bufferSize: bufferSize,
@@ -230,7 +231,7 @@ extension Archive {
             if let size, position >= size {
                 atEnd = true
             }
-            if size == nil && entryChunk.count < readSize {
+            if size == nil && entryChunk.count == 0 {
                 atEnd = true
             }
         }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -77,6 +77,8 @@ public final class Archive: Sequence {
         case invalidBufferSize
         /// Thrown when uncompressedSize/compressedSize exceeds `Int64.max` (Imposed by file API).
         case invalidEntrySize
+        /// Thrown when uncompressed size for a symbolic link is passed as nil
+        case missingEntrySize
         /// Thrown when the offset of local header data exceeds `Int64.max` (Imposed by file API).
         case invalidLocalHeaderDataOffset
         /// Thrown when the size of local header exceeds `Int64.max` (Imposed by file API).

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -60,12 +60,12 @@ extension Data {
 
     /// Compress the output of `provider` and pass it to `consumer`.
     /// - Parameters:
-    ///   - size: The uncompressed size of the data to be compressed.
+    ///   - size: The uncompressed size of the data to be compressed, or nil if not known, in which case provider will be called until it returns an empty Data chunk.
     ///   - bufferSize: The maximum size of the compression buffer.
     ///   - provider: A closure that accepts a position and a chunk size. Returns a `Data` chunk.
     ///   - consumer: A closure that processes the result of the compress operation.
-    /// - Returns: The checksum of the processed content.
-    public static func compress(size: Int64, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    /// - Returns: The total size of uncompressed data consumed, and checksum of the processed content.
+    public static func compress(size: Int64?, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> (Int64, CRC32) {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         return try self.process(operation: COMPRESSION_STREAM_ENCODE, size: size, bufferSize: bufferSize,
                                 provider: provider, consumer: consumer)
@@ -85,8 +85,9 @@ extension Data {
     public static func decompress(size: Int64, bufferSize: Int, skipCRC32: Bool,
                                   provider: Provider, consumer: Consumer) throws -> CRC32 {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
+        let (_, crc) =  try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
                                 skipCRC32: skipCRC32, provider: provider, consumer: consumer)
+        return crc
         #else
         return try self.decode(bufferSize: bufferSize, skipCRC32: skipCRC32, provider: provider, consumer: consumer)
         #endif
@@ -100,8 +101,8 @@ import Compression
 
 extension Data {
 
-    static func process(operation: compression_stream_operation, size: Int64, bufferSize: Int, skipCRC32: Bool = false,
-                        provider: Provider, consumer: Consumer) throws -> CRC32 {
+    static func process(operation: compression_stream_operation, size: Int64? = nil, bufferSize: Int, skipCRC32: Bool = false,
+                        provider: Provider, consumer: Consumer) throws -> (Int64, CRC32) {
         var crc32 = CRC32(0)
         let destPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer { destPointer.deallocate() }
@@ -119,12 +120,11 @@ extension Data {
         repeat {
             let isExhausted = stream.src_size == 0
             if isExhausted {
-                do {
-                    sourceData = try provider(position, Int(Swift.min((size - position), Int64(bufferSize))))
-                    position += Int64(stream.prepare(for: sourceData))
-                } catch { throw error }
+                let remaining = size != nil ? Int64(size! - position) : Int64(bufferSize)
+                sourceData = try provider(position, Int(Swift.min(remaining, Int64(bufferSize))))
+                position += Int64(stream.prepare(for: sourceData))
             }
-            if let sourceData = sourceData {
+            if let sourceData {
                 sourceData.withUnsafeBytes { rawBufferPointer in
                     if let baseAddress = rawBufferPointer.baseAddress {
                         let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
@@ -146,7 +146,7 @@ extension Data {
             default: throw CompressionError.corruptedData
             }
         } while status == COMPRESSION_STATUS_OK
-        return crc32
+        return (position, crc32)
     }
 }
 
@@ -166,7 +166,7 @@ private extension compression_stream {
 import CZlib
 
 extension Data {
-    static func encode(size: Int64, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+    static func encode(size: Int64?, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
         var stream = z_stream()
         let streamSize = Int32(MemoryLayout<z_stream>.size)
         var result = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION,
@@ -177,7 +177,8 @@ extension Data {
         var position: Int64 = 0
         var zipCRC32 = CRC32(0)
         repeat {
-            let readSize = Int(Swift.min((size - position), Int64(bufferSize)))
+            let remaining = size != nil ? Int64(size! - position) : Int64(bufferSize)
+            let readSize = Int(Swift.min(remaining, Int64(bufferSize)))
             var inputChunk = try provider(position, readSize)
             zipCRC32 = inputChunk.crc32(checksum: zipCRC32)
             stream.avail_in = UInt32(inputChunk.count)
@@ -185,7 +186,11 @@ extension Data {
                 if let baseAddress = rawBufferPointer.baseAddress {
                     let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
                     stream.next_in = pointer
-                    flush = position + Int64(bufferSize) >= size ? Z_FINISH : Z_NO_FLUSH
+                    if let size {
+                        flush = position + Int64(bufferSize) >= size ? Z_FINISH : Z_NO_FLUSH
+                    } else {
+                        flush = inputChunk.isEmpty ? Z_FINISH : Z_NO_FLUSH
+                    }
                 } else if rawBufferPointer.count > 0 {
                     throw CompressionError.corruptedData
                 } else {
@@ -211,7 +216,7 @@ extension Data {
             }
             position += Int64(readSize)
         } while flush != Z_FINISH
-        return zipCRC32
+        return (position, zipCRC32)
     }
 
     static func decode(bufferSize: Int, skipCRC32: Bool, provider: Provider, consumer: Consumer) throws -> CRC32 {

--- a/Sources/ZIPFoundation/Data+CompressionDeprecated.swift
+++ b/Sources/ZIPFoundation/Data+CompressionDeprecated.swift
@@ -17,7 +17,8 @@ public extension Data {
                          provider: (_ position: Int, _ size: Int) throws -> Data,
                          consumer: Consumer) throws -> CRC32 {
         let newProvider: Provider = { try provider(Int($0), $1) }
-        return try self.compress(size: Int64(size), bufferSize: bufferSize, provider: newProvider, consumer: consumer)
+        let (_, crc) = try self.compress(size: Int64(size), bufferSize: bufferSize, provider: newProvider, consumer: consumer)
+        return crc
     }
 
     @available(*, deprecated, message: "Please use `Int64` for `size` and provider `position`.")

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -205,6 +205,7 @@ extension ZIPFoundationTests {
             ("testCreateArchiveAddEntryErrorConditions", testCreateArchiveAddEntryErrorConditions),
             ("testCreateArchiveAddZeroSizeUncompressedEntry", testCreateArchiveAddZeroSizeUncompressedEntry),
             ("testCreateArchiveAddZeroSizeCompressedEntry", testCreateArchiveAddZeroSizeCompressedEntry),
+            ("testCreateArchiveAddLargeCompressedEntryWithUnknownLength", testCreateArchiveAddLargeCompressedEntryWithUnknownLength),
             ("testCreateArchiveAddLargeCompressedEntry", testCreateArchiveAddLargeCompressedEntry),
             ("testCreateArchiveAddLargeUncompressedEntry", testCreateArchiveAddLargeUncompressedEntry),
             ("testCreateArchiveAddSymbolicLink", testCreateArchiveAddSymbolicLink),


### PR DESCRIPTION
Some situations require streaming compression where the full size of the input/uncompressed data is not known, such as serializing a large number of objects where loading all the objects into memory would be prohibitive. 

# Changes proposed in this PR
* Allow creation of entries without specifying an uncompressedSize

I assume the progress feedback functionality will not work when passing nil for uncompressedSize. This is ok in my particular use case.  I don't think reporting progress is possible when the full size of the data to be compressed is not known.

Thanks for the simple library! Allows us to move off of the aging (and full of warnings/deprecations) minizip library.
