### PR TITLE
Makes Entry.dataOffset public

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -127,7 +127,7 @@ public final class Archive: Sequence {
     public let url: URL
     /// Access mode for an archive file.
     public let accessMode: AccessMode
-    var archiveFile: FILEPointer
+    public var archiveFile: FILEPointer
     var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
     var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
     var pathEncoding: String.Encoding?

--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -74,7 +74,7 @@ extension Data {
         return checksum
     }
 
-    static func readChunk(of size: Int, from file: FILEPointer) throws -> Data {
+    public static func readChunk(of size: Int, from file: FILEPointer) throws -> Data {
         let alignment = MemoryLayout<UInt>.alignment
         #if swift(>=4.1)
         let bytes = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: alignment)

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -198,7 +198,7 @@ public struct Entry: Equatable {
         }
         return size
     }
-    var dataOffset: UInt64 {
+    public var dataOffset: UInt64 {
         var dataOffset = self.centralDirectoryStructure.effectiveRelativeOffsetOfLocalHeader
         dataOffset += UInt64(LocalFileHeader.size)
         dataOffset += UInt64(self.localFileHeader.fileNameLength)


### PR DESCRIPTION
Fixes https://github.com/weichsel/ZIPFoundation/issues/274

Changes proposed in this PR

The archive I am working with has map imagery stored in a folder structure designating levels and tile positions. One entry in the archive is an index for locating tile image data for a given xyz. We use xyz to determine the entry and offset for the image to extract. Byte count is known to us based on information in the index entry.  

This change exposes Entry.dataOffset.  This will allow other applications to pull raw bytes out of the archive given he entry and byte count.

- Verified existing tests work.
- Ran SwiftLint and saw no issues.