### PR TITLE
(fix) provides correct file url in thrown error with permission error

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -57,7 +57,7 @@ extension Archive {
         let type = try FileManager.typeForItem(at: fileURL)
         // symlinks do not need to be readable
         guard type == .symlink || fileManager.isReadableFile(atPath: fileURL.path) else {
-            throw CocoaError(.fileReadNoPermission, userInfo: [NSFilePathErrorKey: url.path])
+            throw CocoaError(.fileReadNoPermission, userInfo: [NSFilePathErrorKey: fileURL.path])
         }
         let modDate = try FileManager.fileModificationDateTimeForItem(at: fileURL)
         let uncompressedSize = type == .directory ? 0 : try FileManager.fileSizeForItem(at: fileURL)


### PR DESCRIPTION
Fixes #
Provides the file with permissions lacking, not the url of the zip archive, in the error thrown.

# Changes proposed in this PR
* 
* 
* 

# Tests performed
* all of them (Ran tests after change)

# Further info for the reviewer
The current behavior is to throw an error when adding an entry to a zip file that cannot be read. This is perfectly reasonable, but the error thrown gives the url of the zip file, not the file with a permission error. The fix simply provides the newly added (or attempted, more like) file url, not the url of the zip file.

# Open Issues
