### PR TITLE
Updated platform requirements in Package@swift-5.9.swift

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,7 @@ let targets: [Target] = [
 let package = Package(
     name: "ZIPFoundation",
     platforms: [
-        .macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v2), .visionOS(.v1)
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4), .visionOS(.v1)
     ],
     products: [
         .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])


### PR DESCRIPTION
Fixes #

# Changes proposed in this PR
* Swift tools v 5.9 generate warnings during compilation because the supported platform versions are set lower than it is allowed. The proposed platform versions are as follows:
- macOS: 10.13 (changed from: 10.11)
- iOS: 11.0  (changed from: 9.0)
- tvOS: 11..  (changed from: 9.0)
- watchOS: 4.0  (changed from: 2)
- visionOS: 1.0 (unchanged)

# Tests performed
Performed a clean build and the warnings are now gone.

# Further info for the reviewer
This change only affects Swift 5.9 and has no effect on previous versions.

# Open Issues
