### PR TITLE
Fix issue when ZIP64 extra field has different size than expected fro…

### DIFF
--- a/Sources/ZIPFoundation/Entry+ZIP64.swift
+++ b/Sources/ZIPFoundation/Entry+ZIP64.swift
@@ -104,7 +104,10 @@ extension Entry.ZIP64ExtendedInformation {
 
     init?(data: Data, fields: [Field]) {
         let headerLength = 4
-        guard fields.reduce(0, { $0 + $1.size }) + headerLength == data.count else { return nil }
+        let tmpDataSize:UInt16 = data.scanValue(start: 2)
+        guard Int(tmpDataSize) + headerLength == data.count else {
+            return nil
+        }
         var readOffset = headerLength
         func value<T>(of field: Field) throws -> T where T: BinaryInteger {
             if fields.contains(field) {
@@ -120,7 +123,7 @@ extension Entry.ZIP64ExtendedInformation {
             }
         }
         do {
-            dataSize = data.scanValue(start: 2)
+            dataSize = tmpDataSize
             uncompressedSize = try value(of: .uncompressedSize)
             compressedSize = try value(of: .compressedSize)
             relativeOffsetOfLocalHeader = try value(of: .relativeOffsetOfLocalHeader)

--- a/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
@@ -132,7 +132,7 @@ extension ZIPFoundationTests {
         let invalidExtraField2 = ZIP64ExtendedInformation(data: Data(extraFieldBytesMissingByte),
                                                           fields: [.compressedSize, .uncompressedSize])
         XCTAssertNil(invalidExtraField2)
-        let extraFieldBytesWithWrongFields: [UInt8] = [0x01, 0x00, 0x10, 0x00, 0x0a, 0x00, 0x00, 0x00,
+        let extraFieldBytesWithWrongFields: [UInt8] = [0x01, 0x00, 0x0a, 0x00, 0x0a, 0x00, 0x00, 0x00,
                                                        0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00,
                                                        0x00, 0x00, 0x00, 0x00]
         let invalidExtraField3 = ZIP64ExtendedInformation(data: Data(extraFieldBytesWithWrongFields),


### PR DESCRIPTION
…m Central directory file header

I encountered a Zip files where Central Directory header, in field diskNumberStart has value 0x0000 when it should have 0xffff for ZIP64 extension.
In this situation ZIPFoundation expect that ZIP64 Extra field will not have information about diskNumberStart and wrongly estimate the size.

# Changes proposed in this PR
Checking the size of ZIP64 extra field from dataSize (data.scanValue(start: 2)), not from fields in CD header which have 0xffff

