### PR TITLE
Update Package@swift-5.9.swift platform info

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,7 @@ let targets: [Target] = [
 let package = Package(
     name: "ZIPFoundation",
     platforms: [
-        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4), .visionOS(.v1)
+        .macOS(.v10_13), .iOS(.v12), .tvOS(.v12), .watchOS(.v4), .visionOS(.v1)
     ],
     products: [
         .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])


### PR DESCRIPTION
Fixes #

`swift package` CLI throws a warning that `v11` is too hold for swift-5.9

```
warning: 'zipfoundation': /Package@swift-5.9.swift:23:32: warning: 'v11' is deprecated: iOS 12.0 is the oldest supported version
        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4), .visionOS(.v1)
                               ^
/Package@swift-5.9.swift:23:45: warning: 'v11' is deprecated: tvOS 12.0 is the oldest supported version
        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4), .visionOS(.v1)
                                            ^
```

# Changes proposed in this PR
* 
* 
* 

# Tests performed


# Further info for the reviewer


# Open Issues
