### PR TITLE
Fix privacy manifest issues

### DIFF
--- a/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy
@@ -2,21 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
         <key>NSPrivacyCollectedDataTypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyCollectedDataType</key>
-                <string></string>
-                <key>NSPrivacyCollectedDataTypeLinked</key>
-                <false/>
-                <key>NSPrivacyCollectedDataTypeTracking</key>
-                <false/>
-                <key>NSPrivacyCollectedDataTypePurposes</key>
-                <array>
-                    <string></string>
-                </array>
-            </dict>
-        </array>
+        <array/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array/>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
             <dict>

--- a/ZIPFoundation.podspec
+++ b/ZIPFoundation.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.visionos.deployment_target = '1.0'
 
   s.source_files = 'Sources/ZIPFoundation/*.swift'
-  s.resource = 'Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy'
+  s.resource_bundles = {'ZIPFoundation_Privacy' => ['Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Fixes two issues related to the privacy manifest:

1. The manifest itself is kind of invalid (as discussed in #313)

Including a NSPrivacyCollectedDataTypes entry but specifying empty strings is incorrect. Instead, you can just specify an empty array for NSPrivacyCollectedDataTypes at the top level. Also, the top level NSPrivacyTracking and NSPrivacyTrackingDomains keys were missing; I've added them with false/empty values as appropriate.

2. The podspec reference for the privacy manifest was problematic.

When static framework linking is used with Cocoapods, files referenced using `resource` are just directly copied into the main app bundle, potentially clobbering each other or main app resources in the process. i.e., the PrivacyInfo.xcprivacy from ZIPFoundation can overwrite the one for the app itself.

The correct way to include PrivacyInfo.xcprivacy is by using `resource_bundles` to create a nested bundle to contain the file. (If dynamic linking is used, this bundle will be nested inside the framework bundle for the pod; if static linking is used, the bundle is nested directly in the main app bundle. In either case, clobbering is avoided.)

(Reference: https://github.com/CocoaPods/CocoaPods/issues/10325)
