### PR TITLE
Remove constraint that zip64 field values be greater than 0

### DIFF
--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -299,19 +299,19 @@ extension Entry.CentralDirectoryStructure {
 extension Entry.CentralDirectoryStructure {
 
     var effectiveCompressedSize: UInt64 {
-        if self.isZIP64, let compressedSize = self.zip64ExtendedInformation?.compressedSize, compressedSize > 0 {
+        if self.isZIP64, let compressedSize = self.zip64ExtendedInformation?.compressedSize {
             return compressedSize
         }
         return UInt64(compressedSize)
     }
     var effectiveUncompressedSize: UInt64 {
-        if self.isZIP64, let uncompressedSize = self.zip64ExtendedInformation?.uncompressedSize, uncompressedSize > 0 {
+        if self.isZIP64, let uncompressedSize = self.zip64ExtendedInformation?.uncompressedSize {
             return uncompressedSize
         }
         return UInt64(uncompressedSize)
     }
     var effectiveRelativeOffsetOfLocalHeader: UInt64 {
-        if self.isZIP64, let offset = self.zip64ExtendedInformation?.relativeOffsetOfLocalHeader, offset > 0 {
+        if self.isZIP64, let offset = self.zip64ExtendedInformation?.relativeOffsetOfLocalHeader {
             return offset
         }
         return UInt64(relativeOffsetOfLocalHeader)


### PR DESCRIPTION
Fixes #318

# Changes proposed in this PR

In ZIP64 archives, certain standard values (like compressed and uncompressed file sizes, and offsets within the archive) are set to 0xFFFFFFFF, and actual values are provided in the ZIP64 extra fields. The code was requiring these values be > 0. If a value was 0, the non-ZIP64 value was returned (0xFFFFFFFF), and thus almost guaranteed to be incorrect.

This patch removes that test for `compressedSize`, `uncompressedSize`, and `relativeOffsetOfLocalHeader`. While it’s unlikely for a file to have zero length, it’s not impossible, and it’s very likely for a local header to be at offset 0.

# Tests performed

I tested this by seeing if I could iterate over the entries of the file in the referenced bug. Before, the iterator would immediately return nothing, now it returns the expected three entries. I didn’t want to add the referenced file to the repo, and wasn’t sure of the best way to add this test.

# Further info for the reviewer

None.

# Open Issues

None.