### PR TITLE
Fixed: Swift error in file Archive+MemoryFile.swift

### DIFF
--- a/Sources/ZIPFoundation/Archive+MemoryFile.swift
+++ b/Sources/ZIPFoundation/Archive+MemoryFile.swift
@@ -42,11 +42,16 @@ class MemoryFile {
         let result = fopencookie(cookie.toOpaque(), mode, stubs)
         #endif
         if append {
-            fseeko(result, 0, SEEK_END)
+            if let unwrappedResult = result {
+                fseeko(unwrappedResult, 0, SEEK_END)
+            } else {
+                return nil
+            }
         }
         return result
     }
 }
+
 
 private extension MemoryFile {
     func readData(buffer: UnsafeMutableRawBufferPointer) -> Int {


### PR DESCRIPTION
Fixes #320

Fixed this smal error occuring during building of the package : 
```
error: value of optional type 'UnsafeMutablePointer<FILE>?' (aka 'Optional<UnsafeMutablePointer<_IO_FILE>>') must be unwrapped to a value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>')
fseeko(result, 0, SEEK_END)
```
# Changes proposed in this PR
The proposed change in the MemoryFile class aims to address a build error related to the unwrapping of an optional value. The error message indicated that result, which is of the type UnsafeMutablePointer<FILE>? (an optional pointer to a file), must be explicitly unwrapped before it can be used in the fseeko function call.


