### PR TITLE
Concurrency and warning fixes

### DIFF
--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 extension Archive {
-    enum ModifyOperation: Int {
+    enum ModifyOperation: Int, Sendable {
         case remove = -1
         case add = 1
     }

--- a/Sources/ZIPFoundation/Archive+ZIP64.swift
+++ b/Sources/ZIPFoundation/Archive+ZIP64.swift
@@ -13,7 +13,7 @@ import Foundation
 let zip64EOCDRecordStructSignature = 0x06064b50
 let zip64EOCDLocatorStructSignature = 0x07064b50
 
-enum ExtraFieldHeaderID: UInt16 {
+enum ExtraFieldHeaderID: UInt16, Sendable {
     case zip64ExtendedInformation = 0x0001
 }
 

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -61,7 +61,7 @@ public final class Archive: Sequence {
     typealias CentralDirectoryStructure = Entry.CentralDirectoryStructure
 
     /// An error that occurs during reading, creating or updating a ZIP file.
-    public enum ArchiveError: Error {
+    public enum ArchiveError: Error, Sendable {
         /// Thrown when an archive file is either damaged or inaccessible.
         case unreadableArchive
         /// Thrown when an archive is either opened with AccessMode.read or the destination file is unwritable.
@@ -95,7 +95,7 @@ public final class Archive: Sequence {
     }
 
     /// The access mode for an `Archive`.
-    public enum AccessMode: UInt {
+    public enum AccessMode: UInt, Sendable {
         /// Indicates that a newly instantiated `Archive` should create its backing file.
         case create
         /// Indicates that a newly instantiated `Archive` should read from an existing backing file.
@@ -105,7 +105,7 @@ public final class Archive: Sequence {
     }
 
     /// The version of an `Archive`
-    enum Version: UInt16 {
+    enum Version: UInt16, Sendable {
         /// The minimum version for deflate compressed archives
         case v20 = 20
         /// The minimum version for archives making use of ZIP64 extensions

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -15,7 +15,7 @@ import zlib
 #endif
 
 /// The compression method of an `Entry` in a ZIP `Archive`.
-public enum CompressionMethod: UInt16 {
+public enum CompressionMethod: UInt16, Sendable {
     /// Indicates that an `Entry` has no compression applied to its contents.
     case none = 0
     /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.
@@ -38,7 +38,7 @@ public typealias Consumer = (_ data: Data) throws -> Void
 public typealias Provider = (_ position: Int64, _ size: Int) throws -> Data
 
 extension Data {
-    enum CompressionError: Error {
+    enum CompressionError: Error, Sendable {
         case invalidStream
         case corruptedData
     }

--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -23,7 +23,7 @@ protocol DataSerializable {
 }
 
 extension Data {
-    public enum DataError: Error {
+    public enum DataError: Error, Sendable {
         case unreadableFile
         case unwritableFile
     }

--- a/Sources/ZIPFoundation/Date+ZIP.swift
+++ b/Sources/ZIPFoundation/Date+ZIP.swift
@@ -65,7 +65,7 @@ extension Date {
 
 private extension Date {
 
-    enum Constants {
+    enum Constants: Sendable {
 #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         static let absoluteTimeIntervalSince1970 = kCFAbsoluteTimeIntervalSince1970
 #else

--- a/Sources/ZIPFoundation/Entry+ZIP64.swift
+++ b/Sources/ZIPFoundation/Entry+ZIP64.swift
@@ -10,13 +10,13 @@
 
 import Foundation
 
-protocol ExtensibleDataField {
+protocol ExtensibleDataField: Sendable {
     var headerID: UInt16 { get }
     var dataSize: UInt16 { get }
 }
 
 extension Entry {
-    enum EntryError: Error {
+    enum EntryError: Error, Sendable {
         case invalidDataError
         case missingPermissionsAttributeError
         case missingModificationDateAttributeError
@@ -63,7 +63,7 @@ extension Entry.CentralDirectoryStructure {
 }
 
 extension Entry.ZIP64ExtendedInformation {
-    enum Field {
+    enum Field: Sendable {
         case uncompressedSize
         case compressedSize
         case relativeOffsetOfLocalHeader

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -17,7 +17,7 @@ import CoreFoundation
 /// Entries are identified by their `path`.
 public struct Entry: Equatable {
     /// The type of an `Entry` in a ZIP `Archive`.
-    public enum EntryType: Int {
+    public enum EntryType: Int, Sendable {
         /// Indicates a regular file.
         case file
         /// Indicates a directory.
@@ -37,14 +37,14 @@ public struct Entry: Equatable {
         }
     }
 
-    enum OSType: UInt {
+    enum OSType: UInt, Sendable {
         case msdos = 0
         case unix = 3
         case osx = 19
         case unused = 20
     }
 
-    struct LocalFileHeader: DataSerializable {
+    struct LocalFileHeader: DataSerializable, Sendable {
         let localFileHeaderSignature = UInt32(localFileHeaderStructSignature)
         let versionNeededToExtract: UInt16
         let generalPurposeBitFlag: UInt16

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
@@ -13,7 +13,7 @@ import XCTest
 
 extension ZIPFoundationTests {
 
-    private enum ZIP64FileManagerTestsError: Error, CustomStringConvertible {
+    private enum ZIP64FileManagerTestsError: Error, CustomStringConvertible, Sendable {
         case failedToZipItem(url: URL)
         case failedToReadArchive(url: URL)
         case failedToUnzipItem

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -153,7 +153,7 @@ extension ZIPFoundationTests {
         linkArchiveURL.appendPathComponent(self.archiveName(for: #function))
         let linkURL = linkArchiveURL.deletingLastPathComponent()
         let linkTarget = linkURL.path
-        let linkArchive = try XCTUnwrap(try? Archive(url: linkArchiveURL, accessMode: .create))
+        let linkArchive = try XCTUnwrap(try Archive(url: linkArchiveURL, accessMode: .create, pathEncoding: nil))
         try? linkArchive.addEntry(with: "link", type: .symlink, uncompressedSize: Int64(4),
                                   provider: { (_, _) -> Data in
             return linkTarget.data(using: .utf8) ?? Data()
@@ -206,7 +206,7 @@ extension ZIPFoundationTests {
 #if os(macOS)
 private struct ZIPInfo: Hashable {
 
-    enum Mode {
+    enum Mode: Sendable {
         case directoryIteration
         case shellParsing
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationMemoryTests.swift
@@ -115,7 +115,7 @@ extension ZIPFoundationTests {
             self.XCTAssertSwiftError(try archive.remove(entryToRemove),
                                      throws: Archive.ArchiveError.unreadableArchive)
         }
-        self.runWithoutMemory {
+        self.runWithoutMemory { // NOTE: This tests causes EXC_BAD_ACCESS
             try? entryRemoval()
         }
         let data = Data.makeRandomData(size: 1024)
@@ -146,7 +146,7 @@ extension ZIPFoundationTests {
                                 throws: Archive.ArchiveError.unreadableArchive)
         }
 
-        self.runWithoutMemory {
+        self.runWithoutMemory { // NOTE: This tests causes EXC_BAD_ACCESS
             try? archiveCreation()
         }
         #endif

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests+ZIP64.swift
@@ -13,12 +13,12 @@ import XCTest
 
 extension ZIPFoundationTests {
 
-    private enum StoreType {
+    private enum StoreType: Sendable {
         case memory
         case file
     }
 
-    private enum ZIP64ReadingTestsError: Error, CustomStringConvertible {
+    private enum ZIP64ReadingTestsError: Error, CustomStringConvertible, Sendable {
         case failedToReadEntry(name: String)
         case failedToExtractEntry(type: StoreType)
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import ZIPFoundation
 
-enum AdditionalDataError: Error {
+enum AdditionalDataError: Error, Sendable {
     case encodingError
     case invalidDataError
 }


### PR DESCRIPTION
Added Sendable conformance to all Enums and fixed some deprecated issues in tests.  Found an error with test but not sure how to fix...

Fixes #
Warnings relating to passing Archive.AccessMode around in concurrency-safe code.

# Changes proposed in this PR
* All enums are now Sendable.

# Tests performed
All (the only two that error have been notated).

# Further info for the reviewer
This is a great repo.  Thanks!
