### PR TITLE
Fix a possible memory leak in Data.readChunk

### DIFF
--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -84,6 +84,7 @@ extension Data {
         let bytesRead = fread(bytes, 1, size, file)
         let error = ferror(file)
         if error > 0 {
+            bytes.deallocate()
             throw DataError.unreadableFile
         }
         #if swift(>=4.1)


### PR DESCRIPTION
There is a memory leak in `Data.readChunk` when `fread` fails to read data.
This PR fixes it by deallocating memory before throwing an exception.

I didn't create an issue for this, as the problem is obvious, but please let me know if an issue is needed.