### PR TITLE
Fix CI Failure on Linux by Running Swift Tests Directly with Docker

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,11 +34,9 @@ jobs:
       matrix:
         tag: ['5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '5.10']
     runs-on: ubuntu-latest
-    container:
-      image: swift:${{ matrix.tag }}
     steps:
       - uses: actions/checkout@v2
-      - run: swift test -c release -Xswiftc -enable-testing
+      - run: docker run --rm -v $(pwd):/workdir -w /workdir swift:${{ matrix.tag }} swift test -c release -Xswiftc -enable-testing
 
   Coverage:
     runs-on: macos-latest


### PR DESCRIPTION
When submitting another PR, I noticed that the CI on Linux was failing. It seems that instead of specifying `container:` in the CI.yml, we can resolve this issue by directly running the `swift test` command using docker.

I'm not sure what the GitHub Actions runner does when the `container:` option is specified, but there doesn't appear to be a significant difference in CI execution time between using `container:` and directly running the docker command.

- **Using `container:`:** 3m52s ~ 5m18s (example: [here](https://github.com/weichsel/ZIPFoundation/actions/runs/9446769361))
- **Using Docker command:** 3m49s ~ 6m18s (example: [here](https://github.com/kbinani/ZIPFoundation/actions/runs/10587729515))