### PR TITLE
Fix resource leak in `Archive#makeBackingConfiguration`

### DIFF
--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -50,6 +50,7 @@ extension Archive {
                 throw POSIXError(errno, path: url.path)
             }
             guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+                fclose(archiveFile)
                 throw ArchiveError.missingEndOfCentralDirectoryRecord
             }
             return BackingConfiguration(file: archiveFile,
@@ -71,6 +72,7 @@ extension Archive {
                 throw POSIXError(errno, path: url.path)
             }
             guard let (eocdRecord, zip64EOCD) = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+                fclose(archiveFile)
                 throw ArchiveError.missingEndOfCentralDirectoryRecord
             }
             fseeko(archiveFile, 0, SEEK_SET)


### PR DESCRIPTION
An exception is thrown before closing a FILE, causing a resource leak.
This PR adds a call to fclose before throwing the exception to fix the leak.