### PR TITLE
fix ~10x performance regression by reverting a change

### DIFF
--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -21,6 +21,7 @@ public let defaultDirectoryPermissions = UInt16(0o755)
 let defaultPOSIXBufferSize = defaultReadChunkSize
 let defaultDirectoryUnitCount = Int64(1)
 let minEndOfCentralDirectoryOffset = Int64(22)
+let maxDirectoryEndOffset = Int64(66000)
 let endOfCentralDirectoryStructSignature = 0x06054b50
 let localFileHeaderStructSignature = 0x04034b50
 let dataDescriptorStructSignature = 0x08074b50
@@ -280,7 +281,7 @@ public final class Archive: Sequence {
         let archiveLength = Int64(ftello(file))
         guard archiveLength >= 0 else { return nil }
 
-        while eocdOffset == 0 && index <= archiveLength {
+        while eocdOffset == 0 && index < maxDirectoryEndOffset && index <= archiveLength {
             fseeko(file, off_t(archiveLength - index), SEEK_SET)
             var potentialDirectoryEndTag: UInt32 = UInt32()
             fread(&potentialDirectoryEndTag, 1, MemoryLayout<UInt32>.size, file)


### PR DESCRIPTION
change was introduced with zip64 support

Fixes #311 

# Changes proposed in this PR
* reverted https://github.com/weichsel/ZIPFoundation/commit/b3ca1e6f050a26b6232d70fe04937bf2a7c282ba#diff-d829f12a7b0fa38c616a3397c9ea1464287b0d0097dee344876fff88b4b28e39L316

# Tests performed
- performance of loading 10,000 files that are zipped is ~10x faster than development, and roughly where it was before the Zip64 changes
- I'm not familiar enough with Zip64 to be able to test what impacts this change has on that functionality

# Further info for the reviewer
- Performance with large numbers of files is critical for us. This 10x improvement is taking a 20s operation down to under 2s

# Open Issues
