### PR TITLE
Fix alignment crash in debug mode

### DIFF
--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -29,12 +29,9 @@ extension Data {
     }
 
     func scanValue<T>(start: Int) -> T {
-        let subdata = self.subdata(in: start..<start+MemoryLayout<T>.size)
-        #if swift(>=5.0)
-        return subdata.withUnsafeBytes { $0.load(as: T.self) }
-        #else
-        return subdata.withUnsafeBytes { $0.pointee }
-        #endif
+        return self.withUnsafeBytes() {
+            $0.loadUnaligned(fromByteOffset: start, as: T.self)
+        }
     }
 
     static func readStruct<T>(from file: FILEPointer, at offset: UInt64)

--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -29,7 +29,7 @@ extension Data {
     }
 
     func scanValue<T>(start: Int) -> T {
-        return self.withUnsafeBytes() {
+        return self.withUnsafeBytes {
             $0.loadUnaligned(fromByteOffset: start, as: T.self)
         }
     }


### PR DESCRIPTION
Fixes #

Recently when testing a nightly Swift snapshot in a project of mine, I came across an alignment crash. It turns out that

1. There is no guarantee that `Data` or `subdata` point to memory with any particular alignment.
2. In this configuration, with `T` being `UInt32`, the `subdata` was in fact *inline* data, which is always aligned on a 2 byte boundary but misaligned for 4 bytes.
3. When compiling in debug mode, `load` checks for proper alignment and aborts in this case.

The solution is to use the `loadUnaligned` call which makes no alignment assumptions.

# Tests performed

All unit tests keep passing.

# Further info for the reviewer

Unfortunately, I have no good isolated reproduction case for the crash, nor can I be more specific about the project in question.

# Open Issues
