### PR TITLE
Improve user experience: change compression method to `deflate`

### DIFF
--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -31,7 +31,7 @@ extension FileManager {
     ///   - progress: A progress object that can be used to track or cancel the zip operation.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func zipItem(at sourceURL: URL, to destinationURL: URL,
-                        shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .none,
+                        shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .deflate,
                         progress: Progress? = nil) throws {
         let fileManager = FileManager()
         guard fileManager.itemExists(at: sourceURL) else {


### PR DESCRIPTION
# Fixes

# Changes proposed in this PR
* Change the default argument compressionMethod to `.deflate` at `zipItem(at:to:shouldKeepParent:compressionMethod:progress)`
# Tests performed
true

# Further info for the reviewer
In the software development industry, it’s a widely accepted convention for libraries to default to a **“compressed”** output rather than “uncompressed.” For instance, popular libraries like `ZipArchive` and `minizip` are designed so that when users provide a source URL and a destination URL, the output at the destination is a compressed zip file by default. This aligns with user expectations and typical workflows.

Currently, ZipFoundation’s default setting is `.none`, which generates an uncompressed zip. While this is a valid design choice, it may cause confusion for users who assume the output will follow the standard behavior seen in similar libraries. In most practical use cases, whether in daily development or production environments, users are looking to create a compressed zip file rather than one that is simply a copy of the input.

To provide a smoother user experience and align with industry best practices, I would suggest changing the default value to .deflate. This small adjustment could make the library more intuitive and user-friendly.

Open Issues
none