### PR TITLE
check for nil

### DIFF
--- a/Sources/ZIPFoundation/Archive+MemoryFile.swift
+++ b/Sources/ZIPFoundation/Archive+MemoryFile.swift
@@ -41,7 +41,7 @@ class MemoryFile {
         let stubs = cookie_io_functions_t(read: readStub, write: writeStub, seek: seekStub, close: closeStub)
         let result = fopencookie(cookie.toOpaque(), mode, stubs)
         #endif
-        if append {
+        if let result, append {
             fseeko(result, 0, SEEK_END)
         }
         return result


### PR DESCRIPTION
Fixes #

# Changes proposed in this PR
* In certain environments, `fseeko(result, 0, SEEK_END)` will fail to build if result is optional.  Added a requirement for result to be non-nil
* 
* 

# Tests performed


# Further info for the reviewer


# Open Issues
