### PR TITLE
Removing read-only attribute for directories

### DIFF
--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -153,7 +153,15 @@ extension FileManager {
     func transferAttributes(from entry: Entry, toItemAtURL url: URL) throws {
         let attributes = FileManager.attributes(from: entry)
         switch entry.type {
-        case .directory, .file:
+        case .directory:
+            // If the directory in the zip file had read-only permissions when it was added, one of the
+            // key-value pairs in "attributes" will be <NSFilePosixPermissions: 365>, which is 555 in octal,
+            // or "r-xr-xr-x". If that attribute gets applied, the directory cannot be written to
+            // anymore and won't get its contents. This strips that attribute off.
+            let attribsWithoutReadonly = attributes.filter {
+                !($0.key == .posixPermissions && ($0.value as? Int) == 365)}
+            try self.setAttributes(attribsWithoutReadonly, ofItemAtURL: url)
+        case .file:
             try self.setAttributes(attributes, ofItemAtURL: url)
         case .symlink:
             try self.setAttributes(attributes, ofItemAtURL: url, traverseLink: false)


### PR DESCRIPTION
Added a check in func TransferAttributes that strips off an attribute if it's a directory and the attribute is a permission-type attribute that is readonly (555, or "r-xr-xr-x").

Fixes #

# Changes proposed in this PR
* Modified the func TransferAttributes so it removes an attribute if it is posixPermissions and has a value of 365, which is 555 ("r-xr-xr-x") in octal. In my testing this fixes the issue of a zip file that has a subfolder embedded within it that had a read-only property on it that prevents the zip file from being unzipped fully.
* 
* 

# Tests performed
Ran the entire suite of tests and all passed.

# Further info for the reviewer
I considered stripping the permission off for any file type if it was a "posixPermission", regardless of what the permission actually was, but using a light touch seemed like perhaps the best approach. That is to say, rather than doing it to all file types, it's restricted to just directory, and only if the permissions is 555. If the permission is something else that is also read-only, like 444, it won't get trapped and removed, but I haven't seen that so far. The problem of read-only zip contents seems to affect zip files coming from Windows no matter what permissions was set on the Windows side. For a zip created on a Mac, it takes the permissions that were on the files/folders prior to zipping (that is, it doesn't make the files/folders read-only unless they actually were read-only during creation). However, coming from Windows, the contents are always set to read-only regardless of what they were in Windows.
fixes #352

# Open Issues
