### PR TITLE
Fix missing optional check on result in Ubuntu Noble

### DIFF
--- a/Sources/ZIPFoundation/Archive+MemoryFile.swift
+++ b/Sources/ZIPFoundation/Archive+MemoryFile.swift
@@ -41,7 +41,7 @@ class MemoryFile {
         let stubs = cookie_io_functions_t(read: readStub, write: writeStub, seek: seekStub, close: closeStub)
         let result = fopencookie(cookie.toOpaque(), mode, stubs)
         #endif
-        if append {
+        if let result, append {
             fseeko(result, 0, SEEK_END)
         }
         return result


### PR DESCRIPTION
Fixes https://github.com/weichsel/ZIPFoundation/issues/356

# Changes proposed in this PR

* Add an optional check for result in `MemoryFile.open(mode:)`

The issue is not really with result but with the API change to `fseeko` in Ubuntu Noble as it now requires the first parameter to be non-optional.