### PR TITLE
Detect path encoding for compatibility

### DIFF
--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -119,8 +119,14 @@ public struct Entry: Equatable {
     }
     /// The `path` of the receiver within a ZIP `Archive`.
     public var path: String {
-        let encoding = self.centralDirectoryStructure.usesUTF8PathEncoding ? String.Encoding.utf8 : .codepage437
-        return self.path(using: encoding)
+        if self.centralDirectoryStructure.usesUTF8PathEncoding {
+            return self.path(using: .utf8)
+        } else {
+            // If encoding not determined, then try to detect to improve the compatibility.
+            var convertedString: NSString?
+            NSString.stringEncoding(for: self.centralDirectoryStructure.fileNameData, convertedString: &convertedString, usedLossyConversion: nil)
+            return String(convertedString ?? "")
+        }
     }
     /// The file attributes of the receiver as key/value pairs.
     ///

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -122,10 +122,18 @@ public struct Entry: Equatable {
         if self.centralDirectoryStructure.usesUTF8PathEncoding {
             return self.path(using: .utf8)
         } else {
-            // If encoding not determined, then try to detect to improve the compatibility.
+            #if os(Linux)
+            return self.path(using: .codepage437)
+            #else
+            // If encoding not determined, detect the string encoding to improve the compatibility.
             var convertedString: NSString?
-            NSString.stringEncoding(for: self.centralDirectoryStructure.fileNameData, convertedString: &convertedString, usedLossyConversion: nil)
+            NSString.stringEncoding(
+                for: self.centralDirectoryStructure.fileNameData,
+                convertedString: &convertedString,
+                usedLossyConversion: nil
+            )
             return String(convertedString ?? "")
+            #endif
         }
     }
     /// The file attributes of the receiver as key/value pairs.


### PR DESCRIPTION
Fixes #373 

# Changes proposed in this PR
* This PR leverages the function [NSString.stringencoding](https://developer.apple.com/documentation/foundation/nsstring/stringencoding(for:encodingoptions:convertedstring:usedlossyconversion:)) to detect and convert the path data into a valid Swift String, to fix the problem when dealing with ZIP files which contains GB-18030 encoded entries. This improvement only takes effective when function `FileManager.unzipItem` is called without specifying the `pathEncoding`, and `centralDirectoryStructure.usesUTF8PathEncoding` is false.

# Tests performed
All existing unit tests are passed

# Further info for the reviewer
N/A

# Open Issues
N/A