### PR TITLE
Update Swift Package manifest to fix x86_64-swift-linux-musl build

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,21 +1,7 @@
 // swift-tools-version:5.9
 import PackageDescription
 
-#if canImport(Compression)
-let targets: [Target] = [
-    .target(name: "ZIPFoundation",
-            resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
-            ]),
-    .testTarget(name: "ZIPFoundationTests", dependencies: ["ZIPFoundation"])
-]
-#else
-let targets: [Target] = [
-    .systemLibrary(name: "CZLib", pkgConfig: "zlib", providers: [.brew(["zlib"]), .apt(["zlib"])]),
-    .target(name: "ZIPFoundation", dependencies: ["CZLib"], cSettings: [.define("_GNU_SOURCE", to: "1")]),
-    .testTarget(name: "ZIPFoundationTests", dependencies: ["ZIPFoundation"])
-]
-#endif
+let linuxPlatforms: [Platform] = [.linux, .openbsd]
 
 let package = Package(
     name: "ZIPFoundation",
@@ -25,6 +11,19 @@ let package = Package(
     products: [
         .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])
     ],
-    targets: targets,
+    targets: [
+        .target(
+            name: "ZIPFoundation",
+            dependencies: [
+                .target(name: "CZLib", condition: .when(platforms: linuxPlatforms))
+            ],
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ],
+            cSettings: [.define("_GNU_SOURCE", to: "1", .when(platforms: linuxPlatforms))]
+        ),
+        .systemLibrary(name: "CZLib", pkgConfig: "zlib", providers: [.brew(["zlib"]), .apt(["zlib"])]),
+        .testTarget(name: "ZIPFoundationTests", dependencies: ["ZIPFoundation"])
+    ],
     swiftLanguageVersions: [.v4, .v4_2, .v5]
 )


### PR DESCRIPTION
### Summary                                                                                                                                                                    

Updated the Swift Package manifest to use platform-conditional dependencies instead of compile-time `#if canImport(Compression)` checks, fixing build issues on Linux  platforms including x86_64-swift-linux-musl.                                                                                                                                   
                                                                                                                                                                                 
 ### Problem

The previous approach using `#if canImport(Compression)` had a critical issue:

1. **Compile-time evaluation limitation**: `canImport(Compression)` is evaluated when Package.swift is compiled, not when the actual target is built. This created unreliable
  behavior on Linux, especially with musl libc.

2. **Implicit platform handling**: The approach relied on compile-time checks rather than explicit platform declarations, preventing SPM from correctly handling
  platform-specific dependencies.

### Reproduction

To reproduce the issue, try building any SPM executable package with ZIPFoundation as a dependency:

```bash
swift build --swift-sdk x86_64-swift-linux-musl
```

The build would fail with the old manifest structure.

### Solution

The new approach uses SPM's native `.when(platforms:)` conditional dependency system:

1. **Explicit platform targeting**: Clearly defines which platforms need CZLib (`[.linux, .openbsd]`) vs. native Compression framework.

2. **Proper dependency resolution**: SPM resolves dependencies correctly before compilation, knowing exactly what's needed for each platform.

3. **Single unified target structure**: One target definition with conditional dependencies instead of duplicated configurations.

### Changes
  - Removed `#if canImport(Compression)` conditional compilation
  - Unified target definitions into a single structure
  - Added CZLib as a conditional dependency for Linux and OpenBSD only
  - Applied `_GNU_SOURCE` conditionally for Linux platforms
  - Maintained backward compatibility across all platforms