### PR TITLE
Fix ZIP64 handling for Outlook OLM and other low-version producers

### DIFF
--- a/Sources/ZIPFoundation/Archive+ZIP64.swift
+++ b/Sources/ZIPFoundation/Archive+ZIP64.swift
@@ -80,8 +80,9 @@ extension Archive.ZIP64EndOfCentralDirectoryRecord {
         self.sizeOfZIP64EndOfCentralDirectoryRecord = data.scanValue(start: 4)
         self.versionMadeBy = data.scanValue(start: 12)
         self.versionNeededToExtract = data.scanValue(start: 14)
-        // Version Needed to Extract: 4.5 - File uses ZIP64 format extensions
-        guard self.versionNeededToExtract >= Archive.Version.v45.rawValue else { return nil }
+        // Note: The ZIP spec recommends versionNeededToExtract >= 4.5 for ZIP64,
+        // but some producers (e.g. Microsoft Outlook OLM export) write valid ZIP64
+        // structures with a lower version. We accept the record if the signature matches.
         self.numberOfDisk = data.scanValue(start: 16)
         self.numberOfDiskStart = data.scanValue(start: 20)
         self.totalNumberOfEntriesOnDisk = data.scanValue(start: 24)

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -297,19 +297,22 @@ extension Entry.CentralDirectoryStructure {
 extension Entry.CentralDirectoryStructure {
 
     var effectiveCompressedSize: UInt64 {
-        if self.isZIP64, let compressedSize = self.zip64ExtendedInformation?.compressedSize, compressedSize > 0 {
+        if self.isZIP64, self.compressedSize == .max,
+           let compressedSize = self.zip64ExtendedInformation?.compressedSize {
             return compressedSize
         }
         return UInt64(compressedSize)
     }
     var effectiveUncompressedSize: UInt64 {
-        if self.isZIP64, let uncompressedSize = self.zip64ExtendedInformation?.uncompressedSize, uncompressedSize > 0 {
+        if self.isZIP64, self.uncompressedSize == .max,
+           let uncompressedSize = self.zip64ExtendedInformation?.uncompressedSize {
             return uncompressedSize
         }
         return UInt64(uncompressedSize)
     }
     var effectiveRelativeOffsetOfLocalHeader: UInt64 {
-        if self.isZIP64, let offset = self.zip64ExtendedInformation?.relativeOffsetOfLocalHeader, offset > 0 {
+        if self.isZIP64, self.relativeOffsetOfLocalHeader == .max,
+           let offset = self.zip64ExtendedInformation?.relativeOffsetOfLocalHeader {
             return offset
         }
         return UInt64(relativeOffsetOfLocalHeader)

--- a/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationArchiveTests+ZIP64.swift
@@ -52,17 +52,19 @@ extension ZIPFoundationTests {
                                                                           additionalDataProvider: {_ -> Data in
                                                                              return Data() })
         XCTAssertNil(invalidEOCDRecord2)
-        let eocdRecordWithWrongVersion: [UInt8] = [0x50, 0x4b, 0x06, 0x06, 0x2c, 0x00, 0x00, 0x00,
-                                                   0x00, 0x00, 0x00, 0x00, 0x1e, 0x03, 0x14, 0x00,
-                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                   0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                   0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                   0x4c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                   0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-        let invalidEOCDRecord3 = Archive.ZIP64EndOfCentralDirectoryRecord(data: Data(eocdRecordWithWrongVersion),
-                                                                          additionalDataProvider: {_ -> Data in
-                                                                             return Data() })
-        XCTAssertNil(invalidEOCDRecord3)
+        // Some ZIP producers (e.g. Microsoft Outlook OLM export) write valid ZIP64
+        // structures with versionNeededToExtract < 4.5. These should be accepted.
+        let eocdRecordWithLowVersion: [UInt8] = [0x50, 0x4b, 0x06, 0x06, 0x2c, 0x00, 0x00, 0x00,
+                                                  0x00, 0x00, 0x00, 0x00, 0x1e, 0x03, 0x14, 0x00,
+                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                  0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                  0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                  0x4c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                  0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        let lowVersionEOCDRecord = Archive.ZIP64EndOfCentralDirectoryRecord(data: Data(eocdRecordWithLowVersion),
+                                                                            additionalDataProvider: {_ -> Data in
+                                                                               return Data() })
+        XCTAssertNotNil(lowVersionEOCDRecord)
     }
 
     func testArchiveZIP64EOCDLocator() {


### PR DESCRIPTION
## Summary

Two issues prevent ZIPFoundation from reading ZIP64 archives produced by **Microsoft Outlook** (OLM export) and potentially other ZIP producers that use ZIP64 structures with non-standard version fields:

### Bug 1: ZIP64 EOCD version check too strict

`ZIP64EndOfCentralDirectoryRecord.init` rejects records where `versionNeededToExtract < 45` (v4.5). Outlook writes ZIP64 structures with `versionNeededToExtract = 10` (v1.0) because it only uses `store` compression. The fallback to the standard EOCD — which has all fields set to `0xFFFF`/`0xFFFFFFFF` (ZIP64 overflow indicators) — makes the central directory offset point to 4 GB, past end of file, resulting in **0 entries**.

**Fix:** Removed the version guard. The ZIP64 EOCD Record signature (`0x06064B50`) is already validated, which is sufficient to identify the record.

### Bug 2: `effectiveXXX` properties reject zero values

`effectiveCompressedSize`, `effectiveUncompressedSize`, and `effectiveRelativeOffsetOfLocalHeader` use `> 0` to decide whether to use the ZIP64 extended information value. This incorrectly treats `0` as "not present" instead of as a legitimate value:

- The **first entry** in any archive has `relativeOffsetOfLocalHeader = 0`
- **Empty files and directories** have `compressedSize = 0` and `uncompressedSize = 0`

When the ZIP64 value is rejected, the code falls back to the 32-bit field which contains `0xFFFFFFFF` → invalid offset → iteration fails on the first entry → **0 entries**.

**Fix:** Changed the condition from `value > 0` to `self.field == .max`, which correctly checks whether the 32-bit field contains the ZIP64 overflow indicator and the ZIP64 value should be used.

## Diagnostic evidence

Tested with a real 41 MB Outlook OLM file (387 entries, 4 email accounts):

| Tool | Entries found |
|------|--------------|
| `zipinfo` | 387 |
| Python `zipfile` | 387 |
| ZIPFoundation 0.9.20 (before fix) | **0** |
| ZIPFoundation (after fix) | **387** |

OLM file structure:
```
EOCD:        entries=0xFFFF, cd_size=0xFFFFFFFF, cd_offset=0xFFFFFFFF
ZIP64 EOCD:  versionNeeded=10, entries=387, cd_offset=41273746
First CD entry: relativeOffsetOfLocalHeader=0xFFFFFFFF, ZIP64 extra: offset=0
```

## Changes

- `Archive+ZIP64.swift`: Removed `versionNeededToExtract >= 45` guard
- `Entry.swift`: Changed `value > 0` to `self.field == .max` in all three `effectiveXXX` properties
- `ZIPFoundationArchiveTests+ZIP64.swift`: Updated test to expect acceptance of low-version ZIP64 records

## Test plan

- [x] All 126 existing ZIPFoundation tests pass
- [x] Tested with real Outlook OLM file (ZIP64 with version 1.0)
- [x] First entry at offset 0 is correctly read
- [x] All 387 entries enumerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)