### PR TITLE
Add support for preserving Apple metadata

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -21,12 +21,18 @@ extension Archive {
     ///   - symlinksValidWithin: Any symlink target that resolves outside this URL is rejected for security reasons.
     ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
     ///   - progress: A progress object that can be used to track or cancel the extract operation.
+    ///   - preservesAppleMetadata: On Darwin platforms, look up the matching `__MACOSX/.../._<name>`
+    ///                             AppleDouble companion entry in the archive (if any) and apply its
+    ///                             extended attributes, Finder info, and resource fork to the file at
+    ///                             `url` after extraction. No-op when `entry` is itself a companion.
+    ///                             Default is `true`.
     /// - Returns: The checksum of the processed content or 0 if the `skipCRC32` flag was set to `true`.
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
     public func extract(_ entry: Entry, to url: URL, bufferSize: Int = defaultReadChunkSize,
                         skipCRC32: Bool = false,
                         symlinksValidWithin: URL? = nil,
-                        progress: Progress? = nil) throws -> CRC32 {
+                        progress: Progress? = nil,
+                        preservesAppleMetadata: Bool = true) throws -> CRC32 {
         guard bufferSize > 0 else {
             throw ArchiveError.invalidBufferSize
         }
@@ -72,7 +78,34 @@ extension Archive {
                                         progress: progress, consumer: consumer)
         }
         try fileManager.transferAttributes(from: entry, toItemAtURL: url)
+        if preservesAppleMetadata {
+            try self.applyAppleDoubleCompanionIfPresent(for: entry, to: url, bufferSize: bufferSize,
+                                                        skipCRC32: skipCRC32)
+        }
         return checksum
+    }
+
+    // MARK: - AppleDouble helpers
+
+    /// Looks up the `__MACOSX/.../._<name>` companion for `entry` within the archive and, if found,
+    /// applies the encoded Apple metadata to the file at `url`. No-op when `entry` is itself a
+    /// companion, when no companion exists, or on non-Darwin platforms.
+    func applyAppleDoubleCompanionIfPresent(for entry: Entry, to url: URL,
+                                            bufferSize: Int = defaultReadChunkSize,
+                                            skipCRC32: Bool = false) throws {
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        // Companion entries do not have companions of their own.
+        guard FileManager.realEntryPath(fromAppleDoubleCompanionPath: entry.path) == nil else { return }
+        guard let companionPath = FileManager.appleDoubleCompanionPath(forEntryPath: entry.path) else { return }
+        guard let companion = self[companionPath] else { return }
+        var buffer = Data()
+        _ = try self.extract(companion, bufferSize: bufferSize, skipCRC32: skipCRC32,
+                             consumer: { buffer.append($0) })
+        guard let payload = AppleDoublePayload.decode(buffer) else { return }
+        FileManager.applyAppleDoublePayload(payload, to: url)
+#else
+        _ = (entry, url, bufferSize, skipCRC32)
+#endif
     }
 
     /// Read a ZIP `Entry` from the receiver and forward its contents to a `Consumer` closure.

--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -11,6 +11,30 @@
 import Foundation
 
 extension Archive {
+
+    /// Mutable byte counter shared across one or more `extract` calls to enforce a cumulative cap
+    /// on decompressed output. Constructed at the top of `unzipItem` and threaded through each
+    /// per-entry extract so a single archive-wide budget can be enforced regardless of how many
+    /// entries (or AppleDouble companions) are extracted.
+    final class ByteBudget {
+        let limit: Int64
+        var consumed: Int64 = 0
+
+        init(limit: Int64) { self.limit = limit }
+
+        /// Wraps `consumer` so each chunk is charged against the budget before being forwarded.
+        /// Throws `ArchiveError.extractedByteLimitExceeded` if the cumulative total would exceed
+        /// `limit`. The check runs before the inner consumer, so the inner side effect (file
+        /// write, in-memory append) does not happen for the overshooting chunk.
+        func wrap(_ consumer: @escaping Consumer) -> Consumer {
+            return { data in
+                self.consumed += Int64(data.count)
+                if self.consumed > self.limit { throw ArchiveError.extractedByteLimitExceeded }
+                try consumer(data)
+            }
+        }
+    }
+
     /// Read a ZIP `Entry` from the receiver and write it to `url`.
     ///
     /// - Parameters:
@@ -20,6 +44,11 @@ extension Archive {
     ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
     ///   - symlinksValidWithin: Any symlink target that resolves outside this URL is rejected for security reasons.
     ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
+    ///   - maxExtractedBytes: Optional cap on the number of decompressed bytes this call may produce
+    ///                        (including any AppleDouble companion). `ArchiveError.extractedByteLimitExceeded`
+    ///                        is thrown if the limit is crossed. Use this to defend against zip bombs when
+    ///                        extracting untrusted archives. Partial output on disk is not cleaned up on
+    ///                        throw — the caller is responsible for that. Default is `nil` (no limit).
     ///   - progress: A progress object that can be used to track or cancel the extract operation.
     ///   - preservesAppleMetadata: On Darwin platforms, look up the matching `__MACOSX/.../._<name>`
     ///                             AppleDouble companion entry in the archive (if any) and apply its
@@ -31,8 +60,24 @@ extension Archive {
     public func extract(_ entry: Entry, to url: URL, bufferSize: Int = defaultReadChunkSize,
                         skipCRC32: Bool = false,
                         symlinksValidWithin: URL? = nil,
+                        maxExtractedBytes: Int64? = nil,
                         progress: Progress? = nil,
                         preservesAppleMetadata: Bool = true) throws -> CRC32 {
+        return try self.extract(entry, to: url, bufferSize: bufferSize, skipCRC32: skipCRC32,
+                                symlinksValidWithin: symlinksValidWithin,
+                                budget: maxExtractedBytes.map { ByteBudget(limit: $0) },
+                                progress: progress,
+                                preservesAppleMetadata: preservesAppleMetadata)
+    }
+
+    /// Internal extract that accepts a shared `ByteBudget`. Used by `unzipItem` to enforce a single
+    /// archive-wide byte cap across all entries.
+    func extract(_ entry: Entry, to url: URL, bufferSize: Int = defaultReadChunkSize,
+                 skipCRC32: Bool = false,
+                 symlinksValidWithin: URL? = nil,
+                 budget: ByteBudget?,
+                 progress: Progress? = nil,
+                 preservesAppleMetadata: Bool = true) throws -> CRC32 {
         guard bufferSize > 0 else {
             throw ArchiveError.invalidBufferSize
         }
@@ -49,7 +94,8 @@ extension Archive {
                 throw POSIXError(errno, path: url.path)
             }
             defer { fclose(destinationFile) }
-            let consumer = { _ = try Data.write(chunk: $0, to: destinationFile) }
+            let rawConsumer: Consumer = { _ = try Data.write(chunk: $0, to: destinationFile) }
+            let consumer = budget?.wrap(rawConsumer) ?? rawConsumer
             checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                         progress: progress, consumer: consumer)
         case .directory:
@@ -62,7 +108,7 @@ extension Archive {
             guard fileManager.itemExists(at: url) == false else {
                 throw CocoaError(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: url.path])
             }
-            let consumer = { (data: Data) in
+            let rawConsumer: Consumer = { (data: Data) in
                 guard let linkPath = String(data: data, encoding: .utf8) else { throw ArchiveError.invalidEntryPath }
 
                 let parentURL = url.deletingLastPathComponent()
@@ -74,13 +120,14 @@ extension Archive {
                 try fileManager.createParentDirectoryStructure(for: url)
                 try fileManager.createSymbolicLink(atPath: url.path, withDestinationPath: linkPath)
             }
+            let consumer = budget?.wrap(rawConsumer) ?? rawConsumer
             checksum = try self.extract(entry, bufferSize: bufferSize, skipCRC32: skipCRC32,
                                         progress: progress, consumer: consumer)
         }
         try fileManager.transferAttributes(from: entry, toItemAtURL: url)
         if preservesAppleMetadata {
             try self.applyAppleDoubleCompanionIfPresent(for: entry, to: url, bufferSize: bufferSize,
-                                                        skipCRC32: skipCRC32)
+                                                        skipCRC32: skipCRC32, budget: budget)
         }
         return checksum
     }
@@ -92,19 +139,22 @@ extension Archive {
     /// companion, when no companion exists, or on non-Darwin platforms.
     func applyAppleDoubleCompanionIfPresent(for entry: Entry, to url: URL,
                                             bufferSize: Int = defaultReadChunkSize,
-                                            skipCRC32: Bool = false) throws {
+                                            skipCRC32: Bool = false,
+                                            budget: ByteBudget? = nil) throws {
 #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         // Companion entries do not have companions of their own.
         guard FileManager.realEntryPath(fromAppleDoubleCompanionPath: entry.path) == nil else { return }
         guard let companionPath = FileManager.appleDoubleCompanionPath(forEntryPath: entry.path) else { return }
         guard let companion = self[companionPath] else { return }
         var buffer = Data()
+        let rawConsumer: Consumer = { buffer.append($0) }
+        let consumer = budget?.wrap(rawConsumer) ?? rawConsumer
         _ = try self.extract(companion, bufferSize: bufferSize, skipCRC32: skipCRC32,
-                             consumer: { buffer.append($0) })
+                             consumer: consumer)
         guard let payload = AppleDoublePayload.decode(buffer) else { return }
         FileManager.applyAppleDoublePayload(payload, to: url)
 #else
-        _ = (entry, url, bufferSize, skipCRC32)
+        _ = (entry, url, bufferSize, skipCRC32, budget)
 #endif
     }
 

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -28,14 +28,20 @@ extension Archive {
     ///                        By default, no compression will be applied.
     ///   - bufferSize: The maximum size of the write buffer and the compression buffer (if needed).
     ///   - progress: A progress object that can be used to track or cancel the add operation.
+    ///   - preservesAppleMetadata: On Darwin platforms, also add a parallel `__MACOSX/.../._<name>`
+    ///                             AppleDouble companion entry that encodes the file's extended
+    ///                             attributes, Finder info, and resource fork. No-op on other
+    ///                             platforms and for companion paths themselves. Default is `true`.
     /// - Throws: An error if the source file cannot be read or the receiver is not writable.
     public func addEntry(with path: String, relativeTo baseURL: URL,
                          compressionMethod: CompressionMethod = .none,
-                         bufferSize: Int = defaultWriteChunkSize, progress: Progress? = nil) throws {
+                         bufferSize: Int = defaultWriteChunkSize, progress: Progress? = nil,
+                         preservesAppleMetadata: Bool = true) throws {
         let fileURL = baseURL.appendingPathComponent(path)
 
         try self.addEntry(with: path, fileURL: fileURL, compressionMethod: compressionMethod,
-                          bufferSize: bufferSize, progress: progress)
+                          bufferSize: bufferSize, progress: progress,
+                          preservesAppleMetadata: preservesAppleMetadata)
     }
 
     /// Write files, directories or symlinks to the receiver.
@@ -47,9 +53,14 @@ extension Archive {
     ///                        By default, no compression will be applied.
     ///   - bufferSize: The maximum size of the write buffer and the compression buffer (if needed).
     ///   - progress: A progress object that can be used to track or cancel the add operation.
+    ///   - preservesAppleMetadata: On Darwin platforms, also add a parallel `__MACOSX/.../._<name>`
+    ///                             AppleDouble companion entry that encodes the file's extended
+    ///                             attributes, Finder info, and resource fork. No-op on other
+    ///                             platforms and for companion paths themselves. Default is `true`.
     /// - Throws: An error if the source file cannot be read or the receiver is not writable.
     public func addEntry(with path: String, fileURL: URL, compressionMethod: CompressionMethod = .none,
-                         bufferSize: Int = defaultWriteChunkSize, progress: Progress? = nil) throws {
+                         bufferSize: Int = defaultWriteChunkSize, progress: Progress? = nil,
+                         preservesAppleMetadata: Bool = true) throws {
         let fileManager = FileManager()
         guard fileManager.itemExists(at: fileURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: fileURL.path])
@@ -95,6 +106,41 @@ extension Archive {
                               compressionMethod: compressionMethod, bufferSize: bufferSize,
                               progress: progress, provider: provider)
         }
+        if preservesAppleMetadata {
+            try self.addAppleDoubleCompanionIfNeeded(for: path, fileURL: fileURL,
+                                                     compressionMethod: compressionMethod,
+                                                     bufferSize: bufferSize)
+        }
+    }
+
+    // MARK: - AppleDouble helpers
+
+    /// Reads Apple-specific metadata (xattrs, Finder info, resource fork) from the item at
+    /// `fileURL` and, if any is present, writes an AppleDouble companion entry at
+    /// `__MACOSX/.../._<name>`. Has no effect for paths that are already `__MACOSX/` companions
+    /// themselves, or on non-Darwin platforms (where source files have no Apple metadata to read).
+    func addAppleDoubleCompanionIfNeeded(for entryPath: String, fileURL: URL,
+                                         compressionMethod: CompressionMethod,
+                                         bufferSize: Int = defaultWriteChunkSize) throws {
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        guard let companionPath = FileManager.appleDoubleCompanionPath(forEntryPath: entryPath) else { return }
+        guard let payload = FileManager.readAppleDoublePayload(at: fileURL) else { return }
+        let data = payload.encode()
+        let modDate = (try? FileManager.fileModificationDateTimeForItem(at: fileURL)) ?? Date()
+        try self.addEntry(with: companionPath, type: .file,
+                          uncompressedSize: Int64(data.count),
+                          modificationDate: modDate,
+                          permissions: defaultFilePermissions,
+                          compressionMethod: compressionMethod,
+                          bufferSize: bufferSize,
+                          provider: { position, chunkSize -> Data in
+                              let start = Int(position)
+                              let end = Swift.min(start + chunkSize, data.count)
+                              return data.subdata(in: start..<end)
+                          })
+#else
+        _ = (entryPath, fileURL, compressionMethod, bufferSize)
+#endif
     }
 
     /// Write files, directories or symlinks to the receiver.

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -93,6 +93,8 @@ public final class Archive: Sequence {
         case missingEndOfCentralDirectoryRecord
         /// Thrown when an entry contains a symlink pointing to a path outside the destination directory.
         case uncontainedSymlink
+        /// Thrown when an extract operation produced more bytes than the `maxExtractedBytes` limit allowed.
+        case extractedByteLimitExceeded
     }
 
     /// The access mode for an `Archive`.

--- a/Sources/ZIPFoundation/FileManager+AppleDouble.swift
+++ b/Sources/ZIPFoundation/FileManager+AppleDouble.swift
@@ -118,22 +118,18 @@ extension AppleDoublePayload {
     func encode() -> Data {
         var output = Data()
 
-        let hasFinderInfo = (finderInfo?.isEmpty == false) || !extendedAttributes.isEmpty
-        let hasResourceFork = (resourceFork?.isEmpty == false)
-        var numEntries: UInt16 = 0
-        if hasFinderInfo { numEntries += 1 }
-        if hasResourceFork { numEntries += 1 }
+        // Apple always emits both FinderInfo and ResourceFork descriptors (with length=0 for absent
+        // sections). Archive Utility relies on this shape and ignores containers missing either one.
+        let numEntries: UInt16 = 2
 
-        // Build the FinderInfo + optional xattr section in memory first so we know its size.
+        // Always emit a 32-byte FinderInfo section (zero-filled when absent), matching Apple's layout.
         var finderInfoSection = Data()
-        if hasFinderInfo {
-            var finderInfoBytes = Data(count: AppleDouble.finderInfoSize)
-            if let fi = finderInfo {
-                let copyLen = min(fi.count, AppleDouble.finderInfoSize)
-                finderInfoBytes.replaceSubrange(0..<copyLen, with: fi.prefix(copyLen))
-            }
-            finderInfoSection.append(finderInfoBytes)
+        var finderInfoBytes = Data(count: AppleDouble.finderInfoSize)
+        if let fi = finderInfo {
+            let copyLen = min(fi.count, AppleDouble.finderInfoSize)
+            finderInfoBytes.replaceSubrange(0..<copyLen, with: fi.prefix(copyLen))
         }
+        finderInfoSection.append(finderInfoBytes)
 
         let headerPlusEntriesSize = AppleDouble.headerSize + Int(numEntries) * AppleDouble.entryDescriptorSize
         let finderInfoOffset = headerPlusEntriesSize
@@ -160,7 +156,10 @@ extension AppleDoublePayload {
                 attrOffsets.append(dataStart + dataLength)
                 dataLength += value.count
             }
-            let totalSize = AppleDouble.attrHeaderBaseSize + entriesSize + dataLength
+            // Apple encodes `total_size` as the absolute file offset of the end of the xattr data
+            // (equivalently: where the resource fork begins, or EOF when no resource fork).
+            // xnu's xattr reader validates this field; a wrong value causes all xattrs to be ignored.
+            let totalSize = dataStart + dataLength
 
             // Attr header
             var attrSection = Data()
@@ -213,21 +212,17 @@ extension AppleDoublePayload {
         if filler.count < 16 { output.append(Data(count: 16 - filler.count)) }
         output.appendBE16(numEntries)
 
-        // Entry descriptors — FinderInfo first if present, then ResourceFork.
-        if hasFinderInfo {
-            output.appendBE32(AppleDouble.EntryID.finderInfo.rawValue)
-            output.appendBE32(UInt32(finderInfoOffset))
-            output.appendBE32(UInt32(finderInfoLength))
-        }
-        if hasResourceFork {
-            output.appendBE32(AppleDouble.EntryID.resourceFork.rawValue)
-            output.appendBE32(UInt32(resourceForkOffset))
-            output.appendBE32(UInt32(resourceForkLength))
-        }
+        // Entry descriptors — FinderInfo first, then ResourceFork (both always present).
+        output.appendBE32(AppleDouble.EntryID.finderInfo.rawValue)
+        output.appendBE32(UInt32(finderInfoOffset))
+        output.appendBE32(UInt32(finderInfoLength))
+        output.appendBE32(AppleDouble.EntryID.resourceFork.rawValue)
+        output.appendBE32(UInt32(resourceForkOffset))
+        output.appendBE32(UInt32(resourceForkLength))
 
         // Payload sections.
         output.append(finderInfoSection)
-        if hasResourceFork, let rf = resourceFork { output.append(rf) }
+        if let rf = resourceFork, !rf.isEmpty { output.append(rf) }
 
         return output
     }
@@ -287,10 +282,12 @@ extension AppleDoublePayload {
         guard fullData.readBE32(at: attrMagicOffset) == AppleDouble.attrMagic else {
             return (finderInfo, [])
         }
+        // `total_size` is the absolute file offset of the end of the xattr data section (where the
+        // resource fork begins, or EOF when no resource fork). See the encoder for details.
         let totalSize = Int(fullData.readBE32(at: attrMagicOffset + 8))
         let dataStart = Int(fullData.readBE32(at: attrMagicOffset + 12))
         let numAttrs = Int(fullData.readBE16(at: attrMagicOffset + 34))
-        guard attrMagicOffset + totalSize <= fullData.count else { return (finderInfo, []) }
+        guard totalSize <= fullData.count else { return (finderInfo, []) }
         guard dataStart <= fullData.count else { return (finderInfo, []) }
         var entryCursor = attrMagicOffset + AppleDouble.attrHeaderBaseSize
         var results: [(name: String, data: Data)] = []

--- a/Sources/ZIPFoundation/FileManager+AppleDouble.swift
+++ b/Sources/ZIPFoundation/FileManager+AppleDouble.swift
@@ -1,0 +1,443 @@
+//
+//  FileManager+AppleDouble.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017-2026 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+/// AppleDouble (`__MACOSX/._<name>`) helpers.
+///
+/// Apple-produced ZIP archives (Archive Utility, `ditto --sequesterRsrc`) preserve macOS-specific
+/// file metadata — extended attributes, resource forks, and Finder info — by storing a parallel
+/// `__MACOSX/.../._<name>` entry alongside each real entry. Each companion entry is an AppleDouble
+/// (v2) container embedding the metadata.
+///
+/// On Darwin, we round-trip this metadata via the `com.apple.FinderInfo`, `com.apple.ResourceFork`,
+/// and user-namespace extended attributes (`listxattr`/`setxattr`).
+extension FileManager {
+
+    static let macOSXDirectoryName = "__MACOSX"
+    static let appleDoubleFilePrefix = "._"
+
+    /// Returns the `__MACOSX/.../._<name>` companion path for the given entry path,
+    /// or `nil` if no companion is meaningful (e.g. empty path, or a path already inside `__MACOSX/`).
+    static func appleDoubleCompanionPath(forEntryPath path: String) -> String? {
+        guard !path.isEmpty else { return nil }
+        // Strip trailing slash for directory entries — the companion is always a file.
+        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed != macOSXDirectoryName,
+              !trimmed.hasPrefix(macOSXDirectoryName + "/") else { return nil }
+        if let idx = trimmed.lastIndex(of: "/") {
+            let parent = String(trimmed[..<idx])
+            let name = String(trimmed[trimmed.index(after: idx)...])
+            guard !name.isEmpty else { return nil }
+            return "\(macOSXDirectoryName)/\(parent)/\(appleDoubleFilePrefix)\(name)"
+        } else {
+            return "\(macOSXDirectoryName)/\(appleDoubleFilePrefix)\(trimmed)"
+        }
+    }
+
+    /// Returns the real entry path that the given companion path refers to, or `nil` if `path`
+    /// is not a recognizable `__MACOSX/.../._<name>` companion.
+    static func realEntryPath(fromAppleDoubleCompanionPath path: String) -> String? {
+        let prefix = macOSXDirectoryName + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        let rest = String(path.dropFirst(prefix.count))
+        guard !rest.isEmpty, !rest.hasSuffix("/") else { return nil }
+        if let idx = rest.lastIndex(of: "/") {
+            let parent = String(rest[..<idx])
+            let basename = String(rest[rest.index(after: idx)...])
+            guard basename.hasPrefix(appleDoubleFilePrefix) else { return nil }
+            let realBasename = String(basename.dropFirst(appleDoubleFilePrefix.count))
+            guard !realBasename.isEmpty else { return nil }
+            return parent.isEmpty ? realBasename : parent + "/" + realBasename
+        } else {
+            guard rest.hasPrefix(appleDoubleFilePrefix) else { return nil }
+            let realBasename = String(rest.dropFirst(appleDoubleFilePrefix.count))
+            guard !realBasename.isEmpty else { return nil }
+            return realBasename
+        }
+    }
+}
+
+// MARK: - AppleDouble v2 format
+
+enum AppleDouble {
+
+    static let magic: UInt32 = 0x00051607
+    static let version: UInt32 = 0x00020000
+    static let headerSize = 26 // 4 (magic) + 4 (version) + 16 (filler) + 2 (numEntries)
+    static let entryDescriptorSize = 12 // 4 (type) + 4 (offset) + 4 (length)
+
+    enum EntryID: UInt32 {
+        case dataFork = 1
+        case resourceFork = 2
+        case finderInfo = 9
+    }
+
+    // Apple's extended attribute section in the AppleDouble FinderInfo entry.
+    // See xnu's bsd/vfs/vfs_xattr.c.
+    static let attrMagic: UInt32 = 0x41545452 // 'ATTR'
+    static let attrHeaderBaseSize = 36 // everything after the apple_double_header
+    static let finderInfoSize = 32
+    static let finderInfoPadSize = 2
+    static let maxAttrNameLength = 128
+}
+
+struct AppleDoublePayload {
+    /// Standard Finder info (32 bytes). Empty `Data` or `nil` indicates no finder info.
+    var finderInfo: Data?
+    /// Resource fork contents.
+    var resourceFork: Data?
+    /// Other extended attributes, keyed by name, preserved in insertion order.
+    var extendedAttributes: [(name: String, data: Data)]
+
+    init(finderInfo: Data? = nil, resourceFork: Data? = nil,
+         extendedAttributes: [(name: String, data: Data)] = []) {
+        self.finderInfo = finderInfo
+        self.resourceFork = resourceFork
+        self.extendedAttributes = extendedAttributes
+    }
+
+    var isEmpty: Bool {
+        (finderInfo?.isEmpty ?? true) && (resourceFork?.isEmpty ?? true) && extendedAttributes.isEmpty
+    }
+}
+
+// MARK: - Serialization
+
+extension AppleDoublePayload {
+
+    /// Encodes the payload as an AppleDouble v2 container.
+    func encode() -> Data {
+        var output = Data()
+
+        let hasFinderInfo = (finderInfo?.isEmpty == false) || !extendedAttributes.isEmpty
+        let hasResourceFork = (resourceFork?.isEmpty == false)
+        var numEntries: UInt16 = 0
+        if hasFinderInfo { numEntries += 1 }
+        if hasResourceFork { numEntries += 1 }
+
+        // Build the FinderInfo + optional xattr section in memory first so we know its size.
+        var finderInfoSection = Data()
+        if hasFinderInfo {
+            var finderInfoBytes = Data(count: AppleDouble.finderInfoSize)
+            if let fi = finderInfo {
+                let copyLen = min(fi.count, AppleDouble.finderInfoSize)
+                finderInfoBytes.replaceSubrange(0..<copyLen, with: fi.prefix(copyLen))
+            }
+            finderInfoSection.append(finderInfoBytes)
+        }
+
+        let headerPlusEntriesSize = AppleDouble.headerSize + Int(numEntries) * AppleDouble.entryDescriptorSize
+        let finderInfoOffset = headerPlusEntriesSize
+
+        if !extendedAttributes.isEmpty {
+            // Two pad bytes between finder info and ATTR section (for 4-byte alignment).
+            finderInfoSection.append(Data(count: AppleDouble.finderInfoPadSize))
+
+            // Layout: header (36 bytes) + entry descriptors (variable) + attribute data blobs.
+            // Offsets are absolute from the start of the AppleDouble file.
+            let attrHeaderStart = finderInfoOffset + AppleDouble.finderInfoSize + AppleDouble.finderInfoPadSize
+            var entriesSize = 0
+            for (name, _) in extendedAttributes {
+                // attr_entry_t: offset(4) + length(4) + flags(2) + namelen(1) + name(namelen, NUL-terminated)
+                let nameBytes = Data(name.utf8) + Data([0])
+                let rawEntrySize = 11 + nameBytes.count
+                let padded = (rawEntrySize + 3) & ~3 // round up to 4 bytes
+                entriesSize += padded
+            }
+            let dataStart = attrHeaderStart + AppleDouble.attrHeaderBaseSize + entriesSize
+            var dataLength = 0
+            var attrOffsets: [Int] = []
+            for (_, value) in extendedAttributes {
+                attrOffsets.append(dataStart + dataLength)
+                dataLength += value.count
+            }
+            let totalSize = AppleDouble.attrHeaderBaseSize + entriesSize + dataLength
+
+            // Attr header
+            var attrSection = Data()
+            attrSection.appendBE32(AppleDouble.attrMagic)
+            attrSection.appendBE32(0) // debug_tag
+            attrSection.appendBE32(UInt32(totalSize))
+            attrSection.appendBE32(UInt32(dataStart))
+            attrSection.appendBE32(UInt32(dataLength))
+            // reserved[3]
+            attrSection.appendBE32(0)
+            attrSection.appendBE32(0)
+            attrSection.appendBE32(0)
+            attrSection.appendBE16(0) // flags
+            attrSection.appendBE16(UInt16(extendedAttributes.count))
+
+            // Attr entries
+            for (idx, (name, value)) in extendedAttributes.enumerated() {
+                attrSection.appendBE32(UInt32(attrOffsets[idx]))
+                attrSection.appendBE32(UInt32(value.count))
+                attrSection.appendBE16(0) // flags
+                let nameBytes = Data(name.utf8) + Data([0])
+                attrSection.append(UInt8(nameBytes.count)) // namelen (incl. trailing NUL)
+                attrSection.append(nameBytes)
+                // Pad to 4-byte boundary.
+                let rawEntrySize = 11 + nameBytes.count
+                let padded = (rawEntrySize + 3) & ~3
+                if padded > rawEntrySize {
+                    attrSection.append(Data(count: padded - rawEntrySize))
+                }
+            }
+
+            // Attribute value blobs
+            for (_, value) in extendedAttributes {
+                attrSection.append(value)
+            }
+
+            finderInfoSection.append(attrSection)
+        }
+
+        let finderInfoLength = finderInfoSection.count
+        let resourceForkOffset = finderInfoOffset + finderInfoLength
+        let resourceForkLength = resourceFork?.count ?? 0
+
+        // Apple Double header
+        output.appendBE32(AppleDouble.magic)
+        output.appendBE32(AppleDouble.version)
+        // 16-byte filler — Apple writes "Mac OS X        " (ASCII). Zeros also accepted by all parsers we care about.
+        let filler = "Mac OS X        ".data(using: .ascii) ?? Data(count: 16)
+        output.append(filler.prefix(16))
+        if filler.count < 16 { output.append(Data(count: 16 - filler.count)) }
+        output.appendBE16(numEntries)
+
+        // Entry descriptors — FinderInfo first if present, then ResourceFork.
+        if hasFinderInfo {
+            output.appendBE32(AppleDouble.EntryID.finderInfo.rawValue)
+            output.appendBE32(UInt32(finderInfoOffset))
+            output.appendBE32(UInt32(finderInfoLength))
+        }
+        if hasResourceFork {
+            output.appendBE32(AppleDouble.EntryID.resourceFork.rawValue)
+            output.appendBE32(UInt32(resourceForkOffset))
+            output.appendBE32(UInt32(resourceForkLength))
+        }
+
+        // Payload sections.
+        output.append(finderInfoSection)
+        if hasResourceFork, let rf = resourceFork { output.append(rf) }
+
+        return output
+    }
+
+    /// Parses an AppleDouble v2 container. Returns `nil` if the data is malformed.
+    static func decode(_ data: Data) -> AppleDoublePayload? {
+        guard data.count >= AppleDouble.headerSize else { return nil }
+        guard data.readBE32(at: 0) == AppleDouble.magic else { return nil }
+        // Accept anything with the 0x0002xxxx major version.
+        let version = data.readBE32(at: 4)
+        guard (version >> 16) == 0x0002 else { return nil }
+        let numEntries = Int(data.readBE16(at: 24))
+        let entriesEnd = AppleDouble.headerSize + numEntries * AppleDouble.entryDescriptorSize
+        guard data.count >= entriesEnd else { return nil }
+
+        var payload = AppleDoublePayload()
+        for i in 0..<numEntries {
+            let base = AppleDouble.headerSize + i * AppleDouble.entryDescriptorSize
+            let type = data.readBE32(at: base)
+            let offset = Int(data.readBE32(at: base + 4))
+            let length = Int(data.readBE32(at: base + 8))
+            guard offset >= 0, length >= 0, offset &+ length <= data.count else { return nil }
+            let section = data.subdata(in: data.startIndex.advanced(by: offset)
+                                            ..< data.startIndex.advanced(by: offset + length))
+            switch AppleDouble.EntryID(rawValue: type) {
+            case .finderInfo:
+                let (finderInfo, xattrs) = parseFinderInfoSection(section, fullData: data, sectionOffset: offset)
+                payload.finderInfo = finderInfo
+                payload.extendedAttributes = xattrs
+            case .resourceFork:
+                payload.resourceFork = section
+            default:
+                continue
+            }
+        }
+        return payload
+    }
+
+    private static func parseFinderInfoSection(_ section: Data, fullData: Data, sectionOffset: Int)
+        -> (finderInfo: Data?, xattrs: [(name: String, data: Data)]) {
+        var finderInfo: Data?
+        if section.count >= AppleDouble.finderInfoSize {
+            finderInfo = section.prefix(AppleDouble.finderInfoSize)
+            // Treat all-zero Finder Info as "no finder info" — matches what apps like ditto emit
+            // when only xattrs are present. We still preserve it if non-zero.
+            if finderInfo?.allSatisfy({ $0 == 0 }) == true { finderInfo = nil }
+        }
+        guard section.count > AppleDouble.finderInfoSize + AppleDouble.finderInfoPadSize else {
+            return (finderInfo, [])
+        }
+        // The ATTR section follows the 32 Finder Info bytes + 2 padding bytes. Its internal
+        // offsets are absolute from the start of the AppleDouble file.
+        let attrMagicOffset = sectionOffset + AppleDouble.finderInfoSize + AppleDouble.finderInfoPadSize
+        guard attrMagicOffset + AppleDouble.attrHeaderBaseSize <= fullData.count else {
+            return (finderInfo, [])
+        }
+        guard fullData.readBE32(at: attrMagicOffset) == AppleDouble.attrMagic else {
+            return (finderInfo, [])
+        }
+        let totalSize = Int(fullData.readBE32(at: attrMagicOffset + 8))
+        let dataStart = Int(fullData.readBE32(at: attrMagicOffset + 12))
+        let numAttrs = Int(fullData.readBE16(at: attrMagicOffset + 34))
+        guard attrMagicOffset + totalSize <= fullData.count else { return (finderInfo, []) }
+        guard dataStart <= fullData.count else { return (finderInfo, []) }
+        var entryCursor = attrMagicOffset + AppleDouble.attrHeaderBaseSize
+        var results: [(name: String, data: Data)] = []
+        for _ in 0..<numAttrs {
+            guard entryCursor + 11 <= fullData.count else { break }
+            let valueOffset = Int(fullData.readBE32(at: entryCursor))
+            let valueLength = Int(fullData.readBE32(at: entryCursor + 4))
+            let nameLen = Int(fullData[fullData.startIndex.advanced(by: entryCursor + 10)])
+            guard nameLen > 0, entryCursor + 11 + nameLen <= fullData.count else { break }
+            let nameRange = (entryCursor + 11)..<(entryCursor + 11 + nameLen - 1) // strip trailing NUL
+            let nameData = fullData.subdata(in: fullData.startIndex.advanced(by: nameRange.lowerBound)
+                                                ..< fullData.startIndex.advanced(by: nameRange.upperBound))
+            guard let name = String(data: nameData, encoding: .utf8), !name.isEmpty else { break }
+            guard valueOffset >= 0, valueLength >= 0,
+                  valueOffset + valueLength <= fullData.count else { break }
+            let valueData = fullData.subdata(in: fullData.startIndex.advanced(by: valueOffset)
+                                                  ..< fullData.startIndex.advanced(by: valueOffset + valueLength))
+            results.append((name: name, data: valueData))
+            let rawEntrySize = 11 + nameLen
+            let padded = (rawEntrySize + 3) & ~3
+            entryCursor += padded
+        }
+        return (finderInfo, results)
+    }
+}
+
+// MARK: - Big-endian helpers
+
+fileprivate extension Data {
+
+    mutating func appendBE32(_ value: UInt32) {
+        Swift.withUnsafeBytes(of: value.bigEndian) { append(contentsOf: $0) }
+    }
+
+    mutating func appendBE16(_ value: UInt16) {
+        Swift.withUnsafeBytes(of: value.bigEndian) { append(contentsOf: $0) }
+    }
+
+    func readBE32(at offset: Int) -> UInt32 {
+        withUnsafeBytes {
+            UInt32(bigEndian: $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self))
+        }
+    }
+
+    func readBE16(at offset: Int) -> UInt16 {
+        withUnsafeBytes {
+            UInt16(bigEndian: $0.loadUnaligned(fromByteOffset: offset, as: UInt16.self))
+        }
+    }
+}
+
+// MARK: - File-system bridge (Darwin only)
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+
+extension FileManager {
+
+    static let finderInfoXattrName = "com.apple.FinderInfo"
+    static let resourceForkXattrName = "com.apple.ResourceFork"
+
+    /// Builds an `AppleDoublePayload` from the file at `url` by reading its extended attributes
+    /// (including `com.apple.FinderInfo` and `com.apple.ResourceFork`). Returns `nil` when the file
+    /// has no Apple-specific metadata.
+    static func readAppleDoublePayload(at url: URL) -> AppleDoublePayload? {
+        let fsRep = FileManager().fileSystemRepresentation(withPath: url.path)
+        guard let names = listExtendedAttributeNames(fsRep: fsRep), !names.isEmpty else { return nil }
+        var payload = AppleDoublePayload()
+        for name in names {
+            guard let value = getExtendedAttribute(fsRep: fsRep, name: name) else { continue }
+            switch name {
+            case finderInfoXattrName:
+                payload.finderInfo = value
+            case resourceForkXattrName:
+                payload.resourceFork = value
+            default:
+                payload.extendedAttributes.append((name: name, data: value))
+            }
+        }
+        return payload.isEmpty ? nil : payload
+    }
+
+    /// Applies the given `AppleDoublePayload` to the file at `url` by writing its extended attributes.
+    /// Missing / unreadable attributes are ignored; failures are only thrown for hard errors.
+    static func applyAppleDoublePayload(_ payload: AppleDoublePayload, to url: URL) {
+        let fsRep = FileManager().fileSystemRepresentation(withPath: url.path)
+        if let fi = payload.finderInfo, !fi.isEmpty {
+            // Finder Info is always 32 bytes.
+            let trimmed = fi.count >= AppleDouble.finderInfoSize
+                ? fi.prefix(AppleDouble.finderInfoSize)
+                : fi + Data(count: AppleDouble.finderInfoSize - fi.count)
+            setExtendedAttribute(fsRep: fsRep, name: finderInfoXattrName, value: Data(trimmed))
+        }
+        if let rf = payload.resourceFork, !rf.isEmpty {
+            setExtendedAttribute(fsRep: fsRep, name: resourceForkXattrName, value: rf)
+        }
+        for (name, value) in payload.extendedAttributes {
+            setExtendedAttribute(fsRep: fsRep, name: name, value: value)
+        }
+    }
+
+    private static func listExtendedAttributeNames(fsRep: UnsafePointer<CChar>) -> [String]? {
+        let size = listxattr(fsRep, nil, 0, XATTR_NOFOLLOW)
+        if size < 0 { return nil }
+        if size == 0 { return [] }
+        var buffer = [CChar](repeating: 0, count: size)
+        let got = buffer.withUnsafeMutableBufferPointer { ptr -> ssize_t in
+            return listxattr(fsRep, ptr.baseAddress, ptr.count, XATTR_NOFOLLOW)
+        }
+        guard got > 0 else { return [] }
+        var names: [String] = []
+        var current = [CChar]()
+        for i in 0..<Int(got) {
+            let c = buffer[i]
+            if c == 0 {
+                if !current.isEmpty {
+                    current.append(0)
+                    if let name = String(validatingUTF8: current) { names.append(name) }
+                    current.removeAll(keepingCapacity: true)
+                }
+            } else {
+                current.append(c)
+            }
+        }
+        return names
+    }
+
+    private static func getExtendedAttribute(fsRep: UnsafePointer<CChar>, name: String) -> Data? {
+        let size = getxattr(fsRep, name, nil, 0, 0, XATTR_NOFOLLOW)
+        if size < 0 { return nil }
+        if size == 0 { return Data() }
+        var data = Data(count: size)
+        let got = data.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) -> ssize_t in
+            guard let base = ptr.baseAddress else { return -1 }
+            return getxattr(fsRep, name, base, ptr.count, 0, XATTR_NOFOLLOW)
+        }
+        guard got >= 0 else { return nil }
+        if got < size { data.removeSubrange(Int(got)..<size) }
+        return data
+    }
+
+    @discardableResult
+    private static func setExtendedAttribute(fsRep: UnsafePointer<CChar>, name: String, value: Data) -> Bool {
+        let result = value.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Int32 in
+            return setxattr(fsRep, name, ptr.baseAddress, value.count, 0, XATTR_NOFOLLOW)
+        }
+        return result == 0
+    }
+}
+
+#endif

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -110,11 +110,40 @@ extension FileManager {
                           skipCRC32: Bool = false, symlinksValidWithin: URL? = nil,
                           progress: Progress? = nil, pathEncoding: String.Encoding? = nil,
                           preservesAppleMetadata: Bool = true) throws {
-        let fileManager = FileManager()
-        guard fileManager.itemExists(at: sourceURL) else {
+        guard self.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
         }
         let archive = try Archive(url: sourceURL, accessMode: .read, pathEncoding: pathEncoding)
+        try self.unzipItem(archive, to: destinationURL,
+                           skipCRC32: skipCRC32, symlinksValidWithin: symlinksValidWithin,
+                           progress: progress, pathEncoding: pathEncoding,
+                           preservesAppleMetadata: preservesAppleMetadata)
+    }
+
+    /// Unzips the contents of an already-opened `Archive` to the destination URL.
+    ///
+    /// Equivalent to `unzipItem(at:to:...)` but accepts an existing `Archive` instead of
+    /// constructing one from a source URL. Useful when the archive is already in memory
+    /// (e.g. opened from `Data`) or has been opened for other purposes.
+    ///
+    /// - Parameters:
+    ///   - archive: An open `Archive` to extract from.
+    ///   - destinationURL: The file URL that identifies the destination directory of the unzip operation.
+    ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
+    ///   - symlinksValidWithin: Any symlink target that resolves outside this URL is rejected for security reasons.
+    ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
+    ///   - progress: A progress object that can be used to track or cancel the unzip operation.
+    ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///   - preservesAppleMetadata: When `true`, `__MACOSX/.../._<name>` AppleDouble companion entries
+    ///                             are not written to disk. On Darwin, their extended attributes and
+    ///                             resource forks are applied to the corresponding real files instead.
+    ///                             When `false`, those entries are extracted verbatim as regular files.
+    ///                             Default is `true`.
+    /// - Throws: Throws an error if the destination URL is not writable.
+    public func unzipItem(_ archive: Archive, to destinationURL: URL,
+                          skipCRC32: Bool = false, symlinksValidWithin: URL? = nil,
+                          progress: Progress? = nil, pathEncoding: String.Encoding? = nil,
+                          preservesAppleMetadata: Bool = true) throws {
         var totalUnitCount = Int64(0)
         let symlinksValidWithin = symlinksValidWithin ?? destinationURL
         if let progress = progress {
@@ -188,7 +217,7 @@ extension FileManager {
         if preservesAppleMetadata {
             for (path, payload) in pendingAppleDouble {
                 let targetURL = destinationURL.appendingPathComponent(path)
-                guard fileManager.itemExists(at: targetURL) else { continue }
+                guard self.itemExists(at: targetURL) else { continue }
                 FileManager.applyAppleDoublePayload(payload, to: targetURL)
             }
         }

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -98,6 +98,11 @@ extension FileManager {
     ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
     ///   - symlinksValidWithin: Any symlink target that resolves outside this URL is rejected for security reasons.
     ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
+    ///   - maxExtractedBytes: Optional cap on the cumulative number of decompressed bytes produced across
+    ///                        all entries (and AppleDouble companions). `ArchiveError.extractedByteLimitExceeded`
+    ///                        is thrown if the limit is crossed. Use this to defend against zip bombs when
+    ///                        extracting untrusted archives. Partial output on disk is not cleaned up on
+    ///                        throw — the caller is responsible for that. Default is `nil` (no limit).
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
     ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
     ///   - preservesAppleMetadata: When `true`, `__MACOSX/.../._<name>` AppleDouble companion entries
@@ -108,6 +113,7 @@ extension FileManager {
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func unzipItem(at sourceURL: URL, to destinationURL: URL,
                           skipCRC32: Bool = false, symlinksValidWithin: URL? = nil,
+                          maxExtractedBytes: Int64? = nil,
                           progress: Progress? = nil, pathEncoding: String.Encoding? = nil,
                           preservesAppleMetadata: Bool = true) throws {
         guard self.itemExists(at: sourceURL) else {
@@ -116,6 +122,7 @@ extension FileManager {
         let archive = try Archive(url: sourceURL, accessMode: .read, pathEncoding: pathEncoding)
         try self.unzipItem(archive, to: destinationURL,
                            skipCRC32: skipCRC32, symlinksValidWithin: symlinksValidWithin,
+                           maxExtractedBytes: maxExtractedBytes,
                            progress: progress, pathEncoding: pathEncoding,
                            preservesAppleMetadata: preservesAppleMetadata)
     }
@@ -132,6 +139,11 @@ extension FileManager {
     ///   - skipCRC32: Optional flag to skip calculation of the CRC32 checksum to improve performance.
     ///   - symlinksValidWithin: Any symlink target that resolves outside this URL is rejected for security reasons.
     ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
+    ///   - maxExtractedBytes: Optional cap on the cumulative number of decompressed bytes produced across
+    ///                        all entries (and AppleDouble companions). `ArchiveError.extractedByteLimitExceeded`
+    ///                        is thrown if the limit is crossed. Use this to defend against zip bombs when
+    ///                        extracting untrusted archives. Partial output on disk is not cleaned up on
+    ///                        throw — the caller is responsible for that. Default is `nil` (no limit).
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
     ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
     ///   - preservesAppleMetadata: When `true`, `__MACOSX/.../._<name>` AppleDouble companion entries
@@ -142,6 +154,7 @@ extension FileManager {
     /// - Throws: Throws an error if the destination URL is not writable.
     public func unzipItem(_ archive: Archive, to destinationURL: URL,
                           skipCRC32: Bool = false, symlinksValidWithin: URL? = nil,
+                          maxExtractedBytes: Int64? = nil,
                           progress: Progress? = nil, pathEncoding: String.Encoding? = nil,
                           preservesAppleMetadata: Bool = true) throws {
         var totalUnitCount = Int64(0)
@@ -150,6 +163,9 @@ extension FileManager {
             totalUnitCount = archive.reduce(0, { $0 + archive.totalUnitCountForReading($1) })
             progress.totalUnitCount = totalUnitCount
         }
+
+        // Single budget shared across every per-entry extract so the cap is cumulative, not per-entry.
+        let budget = maxExtractedBytes.map { Archive.ByteBudget(limit: $0) }
 
         // Companion AppleDouble entries may appear in any order relative to their paired real
         // entries. We buffer the parsed payloads and apply them after the main extraction pass.
@@ -167,7 +183,8 @@ extension FileManager {
                 }
                 if let pairedPath = FileManager.realEntryPath(fromAppleDoubleCompanionPath: path) {
                     var buffer = Data()
-                    let consumer: Consumer = { buffer.append($0) }
+                    let rawConsumer: Consumer = { buffer.append($0) }
+                    let consumer = budget?.wrap(rawConsumer) ?? rawConsumer
                     if let progress = progress {
                         let entryProgress = archive.makeProgressForReading(entry)
                         progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
@@ -196,12 +213,14 @@ extension FileManager {
                 crc32 = try archive.extract(entry, to: entryURL,
                                             skipCRC32: skipCRC32,
                                             symlinksValidWithin: symlinksValidWithin,
+                                            budget: budget,
                                             progress: entryProgress,
                                             preservesAppleMetadata: false)
             } else {
                 crc32 = try archive.extract(entry, to: entryURL,
                                             skipCRC32: skipCRC32,
                                             symlinksValidWithin: symlinksValidWithin,
+                                            budget: budget,
                                             preservesAppleMetadata: false)
             }
 

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -29,10 +29,16 @@ extension FileManager {
     ///   - compressionMethod: Indicates the `CompressionMethod` that should be applied.
     ///                        By default, `zipItem` will create uncompressed archives.
     ///   - progress: A progress object that can be used to track or cancel the zip operation.
+    ///   - preservesAppleMetadata: On Darwin platforms, store extended attributes and resource forks
+    ///                             in parallel `__MACOSX/.../._<name>` AppleDouble entries (the same
+    ///                             convention Archive Utility and `ditto --sequesterRsrc` produce).
+    ///                             Has no effect on non-Darwin platforms, where source files do not
+    ///                             carry macOS-specific metadata. Default is `true`.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func zipItem(at sourceURL: URL, to destinationURL: URL,
                         shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .none,
-                        progress: Progress? = nil) throws {
+                        progress: Progress? = nil,
+                        preservesAppleMetadata: Bool = true) throws {
         let fileManager = FileManager()
         guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
@@ -67,17 +73,20 @@ extension FileManager {
                     let entryProgress = archive.makeProgressForAddingItem(at: itemURL)
                     progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
                     try archive.addEntry(with: finalEntryPath, relativeTo: finalBaseURL,
-                                         compressionMethod: compressionMethod, progress: entryProgress)
+                                         compressionMethod: compressionMethod, progress: entryProgress,
+                                         preservesAppleMetadata: preservesAppleMetadata)
                 } else {
                     try archive.addEntry(with: finalEntryPath, relativeTo: finalBaseURL,
-                                         compressionMethod: compressionMethod)
+                                         compressionMethod: compressionMethod,
+                                         preservesAppleMetadata: preservesAppleMetadata)
                 }
             }
         } else {
             progress?.totalUnitCount = archive.totalUnitCountForAddingItem(at: sourceURL)
             let baseURL = sourceURL.deletingLastPathComponent()
             try archive.addEntry(with: sourceURL.lastPathComponent, relativeTo: baseURL,
-                                 compressionMethod: compressionMethod, progress: progress)
+                                 compressionMethod: compressionMethod, progress: progress,
+                                 preservesAppleMetadata: preservesAppleMetadata)
         }
     }
 
@@ -91,10 +100,16 @@ extension FileManager {
     ///                          Pass `.rootFS` to allow symlinks to point anywhere on the filesystem.
     ///   - progress: A progress object that can be used to track or cancel the unzip operation.
     ///   - pathEncoding: Encoding for entry paths. Overrides the encoding specified in the archive.
+    ///   - preservesAppleMetadata: When `true`, `__MACOSX/.../._<name>` AppleDouble companion entries
+    ///                             are not written to disk. On Darwin, their extended attributes and
+    ///                             resource forks are applied to the corresponding real files instead.
+    ///                             When `false`, those entries are extracted verbatim as regular files.
+    ///                             Default is `true`.
     /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
     public func unzipItem(at sourceURL: URL, to destinationURL: URL,
                           skipCRC32: Bool = false, symlinksValidWithin: URL? = nil,
-                          progress: Progress? = nil, pathEncoding: String.Encoding? = nil) throws {
+                          progress: Progress? = nil, pathEncoding: String.Encoding? = nil,
+                          preservesAppleMetadata: Bool = true) throws {
         let fileManager = FileManager()
         guard fileManager.itemExists(at: sourceURL) else {
             throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path])
@@ -107,25 +122,58 @@ extension FileManager {
             progress.totalUnitCount = totalUnitCount
         }
 
+        // Companion AppleDouble entries may appear in any order relative to their paired real
+        // entries. We buffer the parsed payloads and apply them after the main extraction pass.
+        var pendingAppleDouble: [String: AppleDoublePayload] = [:]
+
         for entry in archive {
             let path = pathEncoding == nil ? entry.path : entry.path(using: pathEncoding!)
+            if preservesAppleMetadata {
+                // Skip the `__MACOSX/` directory marker itself.
+                if path == FileManager.macOSXDirectoryName || path == FileManager.macOSXDirectoryName + "/" {
+                    if let progress = progress {
+                        progress.completedUnitCount += archive.totalUnitCountForReading(entry)
+                    }
+                    continue
+                }
+                if let pairedPath = FileManager.realEntryPath(fromAppleDoubleCompanionPath: path) {
+                    var buffer = Data()
+                    let consumer: Consumer = { buffer.append($0) }
+                    if let progress = progress {
+                        let entryProgress = archive.makeProgressForReading(entry)
+                        progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
+                        _ = try archive.extract(entry, skipCRC32: skipCRC32,
+                                                progress: entryProgress, consumer: consumer)
+                    } else {
+                        _ = try archive.extract(entry, skipCRC32: skipCRC32, consumer: consumer)
+                    }
+                    if let payload = AppleDoublePayload.decode(buffer) {
+                        pendingAppleDouble[pairedPath] = payload
+                    }
+                    continue
+                }
+            }
             let entryURL = destinationURL.appendingPathComponent(path)
             guard entryURL.isContained(in: destinationURL) else {
                 throw CocoaError(.fileReadInvalidFileName,
                                  userInfo: [NSFilePathErrorKey: entryURL.path])
             }
             let crc32: CRC32
+            // unzipItem batches companion handling (see below), so we opt each per-entry extract
+            // out of the per-call archive lookup.
             if let progress = progress {
                 let entryProgress = archive.makeProgressForReading(entry)
                 progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
                 crc32 = try archive.extract(entry, to: entryURL,
                                             skipCRC32: skipCRC32,
                                             symlinksValidWithin: symlinksValidWithin,
-                                            progress: entryProgress)
+                                            progress: entryProgress,
+                                            preservesAppleMetadata: false)
             } else {
                 crc32 = try archive.extract(entry, to: entryURL,
                                             skipCRC32: skipCRC32,
-                                            symlinksValidWithin: symlinksValidWithin)
+                                            symlinksValidWithin: symlinksValidWithin,
+                                            preservesAppleMetadata: false)
             }
 
             func verifyChecksumIfNecessary() throws {
@@ -135,7 +183,20 @@ extension FileManager {
             }
             try verifyChecksumIfNecessary()
         }
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        if preservesAppleMetadata {
+            for (path, payload) in pendingAppleDouble {
+                let targetURL = destinationURL.appendingPathComponent(path)
+                guard fileManager.itemExists(at: targetURL) else { continue }
+                FileManager.applyAppleDoublePayload(payload, to: targetURL)
+            }
+        }
+#else
+        _ = pendingAppleDouble
+#endif
     }
+
 
     // MARK: - Helpers
 

--- a/Tests/ZIPFoundationTests/ZIPFoundationAppleDoubleTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationAppleDoubleTests.swift
@@ -1,0 +1,281 @@
+//
+//  ZIPFoundationAppleDoubleTests.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017-2026 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import XCTest
+@testable import ZIPFoundation
+
+extension ZIPFoundationTests {
+
+    func testAppleDoubleCompanionPathDerivation() {
+        XCTAssertEqual(FileManager.appleDoubleCompanionPath(forEntryPath: "foo.txt"),
+                       "__MACOSX/._foo.txt")
+        XCTAssertEqual(FileManager.appleDoubleCompanionPath(forEntryPath: "dir/foo.txt"),
+                       "__MACOSX/dir/._foo.txt")
+        XCTAssertEqual(FileManager.appleDoubleCompanionPath(forEntryPath: "dir/sub/foo.txt"),
+                       "__MACOSX/dir/sub/._foo.txt")
+        // Trailing slash (directory entries) is stripped so the companion itself is a file.
+        XCTAssertEqual(FileManager.appleDoubleCompanionPath(forEntryPath: "dir/"),
+                       "__MACOSX/._dir")
+        XCTAssertEqual(FileManager.appleDoubleCompanionPath(forEntryPath: "dir/sub/"),
+                       "__MACOSX/dir/._sub")
+        // Companions never nest.
+        XCTAssertNil(FileManager.appleDoubleCompanionPath(forEntryPath: "__MACOSX/._foo"))
+        XCTAssertNil(FileManager.appleDoubleCompanionPath(forEntryPath: "__MACOSX"))
+        XCTAssertNil(FileManager.appleDoubleCompanionPath(forEntryPath: ""))
+        XCTAssertNil(FileManager.appleDoubleCompanionPath(forEntryPath: "/"))
+    }
+
+    func testRealEntryPathFromCompanion() {
+        XCTAssertEqual(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/._foo.txt"),
+                       "foo.txt")
+        XCTAssertEqual(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/dir/._foo.txt"),
+                       "dir/foo.txt")
+        XCTAssertEqual(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/dir/sub/._foo.txt"),
+                       "dir/sub/foo.txt")
+        XCTAssertNil(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "foo.txt"))
+        XCTAssertNil(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/foo.txt"))
+        XCTAssertNil(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/"))
+        XCTAssertNil(FileManager.realEntryPath(fromAppleDoubleCompanionPath: "__MACOSX/._"))
+    }
+
+    func testAppleDoubleEncodingRoundTrip() {
+        let finderInfo = Data([0x54, 0x45, 0x58, 0x54, 0x21, 0x52, 0x63, 0x68] + [UInt8](repeating: 0, count: 24))
+        let resourceFork = Data("fake-resource-fork-bytes".utf8)
+        let xattrs: [(name: String, data: Data)] = [
+            ("com.example.single", Data("abc".utf8)),
+            ("com.example.multi", Data([0x00, 0xFF, 0x42, 0x01, 0x02, 0x03, 0x04]))
+        ]
+        let payload = AppleDoublePayload(finderInfo: finderInfo,
+                                         resourceFork: resourceFork,
+                                         extendedAttributes: xattrs)
+        let encoded = payload.encode()
+        let decoded = AppleDoublePayload.decode(encoded)
+        XCTAssertNotNil(decoded)
+        guard let decoded else { return }
+        XCTAssertEqual(decoded.finderInfo, finderInfo)
+        XCTAssertEqual(decoded.resourceFork, resourceFork)
+        XCTAssertEqual(decoded.extendedAttributes.count, xattrs.count)
+        for (actual, expected) in zip(decoded.extendedAttributes, xattrs) {
+            XCTAssertEqual(actual.name, expected.name)
+            XCTAssertEqual(actual.data, expected.data)
+        }
+    }
+
+    func testAppleDoubleEncodingEmptyFinderInfoIgnored() {
+        // Zero-filled FinderInfo round-trips as "no finder info" — it carries no information and
+        // matches what Apple-produced AppleDouble files typically encode.
+        let xattrs: [(name: String, data: Data)] = [("com.example.only", Data([0xAB, 0xCD]))]
+        let payload = AppleDoublePayload(finderInfo: nil, resourceFork: nil, extendedAttributes: xattrs)
+        let encoded = payload.encode()
+        let decoded = AppleDoublePayload.decode(encoded)
+        XCTAssertNil(decoded?.finderInfo)
+        XCTAssertEqual(decoded?.extendedAttributes.count, 1)
+        XCTAssertEqual(decoded?.extendedAttributes.first?.name, "com.example.only")
+        XCTAssertEqual(decoded?.extendedAttributes.first?.data, Data([0xAB, 0xCD]))
+    }
+
+    func testAppleDoubleDecodeRejectsBadMagic() {
+        var data = AppleDoublePayload(resourceFork: Data([0x01])).encode()
+        data[0] = 0x00 // Corrupt magic
+        data[1] = 0x00
+        data[2] = 0x00
+        data[3] = 0x00
+        XCTAssertNil(AppleDoublePayload.decode(data))
+    }
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+
+    func testZipItemPreservesXattrsOnDarwin() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let sourceDir = sandbox.appendingPathComponent("source", isDirectory: true)
+        let extractDir = sandbox.appendingPathComponent("extracted", isDirectory: true)
+        try fileManager.createDirectory(at: sourceDir, withIntermediateDirectories: true, attributes: nil)
+
+        let fileURL = sourceDir.appendingPathComponent("tagged.txt")
+        try Data("hello".utf8).write(to: fileURL)
+
+        let xattrValue = Data("annotation".utf8)
+        try self.setXattr(name: "com.example.note", value: xattrValue, at: fileURL)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        try fileManager.zipItem(at: sourceDir, to: archiveURL, shouldKeepParent: false)
+
+        // Archive must include the AppleDouble companion.
+        let archive = try Archive(url: archiveURL, accessMode: .read)
+        XCTAssertNotNil(archive["__MACOSX/._tagged.txt"], "Expected AppleDouble companion in archive")
+
+        // Extract and verify xattr round-trips.
+        try fileManager.unzipItem(at: archiveURL, to: extractDir)
+        let extractedFile = extractDir.appendingPathComponent("tagged.txt")
+        XCTAssertTrue(fileManager.itemExists(at: extractedFile))
+        // `__MACOSX` entries should not land on disk.
+        XCTAssertFalse(fileManager.itemExists(at: extractDir.appendingPathComponent("__MACOSX")))
+
+        let restored = self.getXattr(name: "com.example.note", at: extractedFile)
+        XCTAssertEqual(restored, xattrValue)
+    }
+
+    func testZipItemPreservesResourceForkOnDarwin() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let sourceDir = sandbox.appendingPathComponent("source", isDirectory: true)
+        let extractDir = sandbox.appendingPathComponent("extracted", isDirectory: true)
+        try fileManager.createDirectory(at: sourceDir, withIntermediateDirectories: true, attributes: nil)
+
+        let fileURL = sourceDir.appendingPathComponent("resourced.bin")
+        try Data("main-data".utf8).write(to: fileURL)
+
+        // Write a resource fork by setting the special xattr.
+        let rfBytes = Data([0x00, 0x00, 0x01, 0x00] + Array("RESOURCE-FORK-PAYLOAD".utf8))
+        try self.setXattr(name: "com.apple.ResourceFork", value: rfBytes, at: fileURL)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        try fileManager.zipItem(at: sourceDir, to: archiveURL, shouldKeepParent: false)
+
+        try fileManager.unzipItem(at: archiveURL, to: extractDir)
+        let extractedFile = extractDir.appendingPathComponent("resourced.bin")
+        let restored = self.getXattr(name: "com.apple.ResourceFork", at: extractedFile)
+        XCTAssertEqual(restored, rfBytes)
+    }
+
+    func testUnzipItemWithPreservesAppleMetadataFalse() throws {
+        // Opting out of AppleDouble handling should fall back to the original behavior where
+        // `__MACOSX` entries land on disk verbatim.
+        let fileManager = FileManager()
+        let archiveURL = self.resourceURL(for: "testUnzipItem", pathExtension: "zip")
+        let destination = self.createDirectory(for: #function)
+        try fileManager.unzipItem(at: archiveURL, to: destination, preservesAppleMetadata: false)
+        XCTAssertTrue(fileManager.itemExists(at: destination.appendingPathComponent("__MACOSX")))
+    }
+
+    func testArchiveAddEntryAddsCompanionOnDarwin() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let fileURL = sandbox.appendingPathComponent("note.txt")
+        try Data("payload".utf8).write(to: fileURL)
+        let xattrValue = Data("user-annotation".utf8)
+        try self.setXattr(name: "com.example.tag", value: xattrValue, at: fileURL)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+        try archive.addEntry(with: "note.txt", relativeTo: sandbox)
+
+        // Primary entry plus AppleDouble companion.
+        XCTAssertNotNil(archive["note.txt"])
+        XCTAssertNotNil(archive["__MACOSX/._note.txt"])
+    }
+
+    func testArchiveAddEntryRespectsPreservesAppleMetadataFalse() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let fileURL = sandbox.appendingPathComponent("plain.txt")
+        try Data("payload".utf8).write(to: fileURL)
+        try self.setXattr(name: "com.example.tag", value: Data("tag".utf8), at: fileURL)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+        try archive.addEntry(with: "plain.txt", relativeTo: sandbox, preservesAppleMetadata: false)
+
+        XCTAssertNotNil(archive["plain.txt"])
+        XCTAssertNil(archive["__MACOSX/._plain.txt"])
+    }
+
+    func testArchiveExtractAppliesCompanion() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let sourceFile = sandbox.appendingPathComponent("doc.txt")
+        try Data("content".utf8).write(to: sourceFile)
+        let tag = Data("meta".utf8)
+        try self.setXattr(name: "com.example.tag", value: tag, at: sourceFile)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+        try archive.addEntry(with: "doc.txt", relativeTo: sandbox)
+
+        // Extract only the real entry via the low-level API and verify xattr is applied.
+        let destination = sandbox.appendingPathComponent("extracted/doc.txt")
+        guard let realEntry = archive["doc.txt"] else {
+            XCTFail("Missing real entry"); return
+        }
+        _ = try archive.extract(realEntry, to: destination)
+        XCTAssertEqual(self.getXattr(name: "com.example.tag", at: destination), tag)
+    }
+
+    func testArchiveExtractWithoutPreservesAppleMetadataSkipsCompanion() throws {
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let sourceFile = sandbox.appendingPathComponent("doc.txt")
+        try Data("content".utf8).write(to: sourceFile)
+        try self.setXattr(name: "com.example.tag", value: Data("meta".utf8), at: sourceFile)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+        try archive.addEntry(with: "doc.txt", relativeTo: sandbox)
+
+        let destination = sandbox.appendingPathComponent("extracted/doc.txt")
+        guard let realEntry = archive["doc.txt"] else { XCTFail("Missing real entry"); return }
+        _ = try archive.extract(realEntry, to: destination, preservesAppleMetadata: false)
+        XCTAssertNil(self.getXattr(name: "com.example.tag", at: destination))
+    }
+
+    func testArchiveExtractCompanionEntryItselfIsNotReinterpreted() throws {
+        // Extracting the `__MACOSX/._name` entry itself should write it verbatim as an AppleDouble
+        // file (the caller asked for that specific entry).
+        let fileManager = FileManager()
+        let sandbox = self.createDirectory(for: #function)
+        let sourceFile = sandbox.appendingPathComponent("doc.txt")
+        try Data("content".utf8).write(to: sourceFile)
+        try self.setXattr(name: "com.example.tag", value: Data("meta".utf8), at: sourceFile)
+
+        let archiveURL = sandbox.appendingPathComponent("archive.zip")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+        try archive.addEntry(with: "doc.txt", relativeTo: sandbox)
+
+        guard let companion = archive["__MACOSX/._doc.txt"] else {
+            XCTFail("Missing companion entry"); return
+        }
+        let outURL = sandbox.appendingPathComponent("raw-companion")
+        _ = try archive.extract(companion, to: outURL)
+        let rawData = try Data(contentsOf: outURL)
+        XCTAssertNotNil(AppleDoublePayload.decode(rawData))
+    }
+
+    // MARK: - Helpers
+
+    private func setXattr(name: String, value: Data, at url: URL) throws {
+        let fsRep = FileManager().fileSystemRepresentation(withPath: url.path)
+        let bytes = [UInt8](value)
+        let result = bytes.withUnsafeBufferPointer { ptr -> Int32 in
+            setxattr(fsRep, name, ptr.baseAddress, bytes.count, 0, XATTR_NOFOLLOW)
+        }
+        if result != 0 {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno),
+                          userInfo: [NSLocalizedDescriptionKey: "setxattr failed for \(name)"])
+        }
+    }
+
+    private func getXattr(name: String, at url: URL) -> Data? {
+        let fsRep = FileManager().fileSystemRepresentation(withPath: url.path)
+        let size = getxattr(fsRep, name, nil, 0, 0, XATTR_NOFOLLOW)
+        guard size >= 0 else { return nil }
+        if size == 0 { return Data() }
+        var bytes = [UInt8](repeating: 0, count: size)
+        let got = bytes.withUnsafeMutableBufferPointer { ptr -> ssize_t in
+            guard let base = ptr.baseAddress else { return -1 }
+            return getxattr(fsRep, name, base, ptr.count, 0, XATTR_NOFOLLOW)
+        }
+        guard got >= 0 else { return nil }
+        if got < size { bytes.removeSubrange(Int(got)..<size) }
+        return Data(bytes)
+    }
+
+#endif
+}

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -95,6 +95,11 @@ extension ZIPFoundationTests {
         }
         var itemsExist = false
         for entry in archive {
+            // With `preservesAppleMetadata: true` (default), `__MACOSX/.../._<name>` companion
+            // entries are consumed as metadata rather than extracted to disk.
+            if entry.path.hasPrefix(FileManager.macOSXDirectoryName + "/")
+                || entry.path == FileManager.macOSXDirectoryName
+                || entry.path == FileManager.macOSXDirectoryName + "/" { continue }
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
             itemsExist = fileManager.itemExists(at: directoryURL)
             if itemsExist == false { break }
@@ -114,7 +119,11 @@ extension ZIPFoundationTests {
         }
         var itemsExist = false
         for entry in archive {
-            let directoryURL = destinationURL.appendingPathComponent(entry.path(using: encoding))
+            let path = entry.path(using: encoding)
+            if path.hasPrefix(FileManager.macOSXDirectoryName + "/")
+                || path == FileManager.macOSXDirectoryName
+                || path == FileManager.macOSXDirectoryName + "/" { continue }
+            let directoryURL = destinationURL.appendingPathComponent(path)
             itemsExist = fileManager.itemExists(at: directoryURL)
             if !itemsExist { break }
         }

--- a/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationProgressTests.swift
@@ -171,6 +171,9 @@ extension ZIPFoundationTests {
             }
             var itemsExist = false
             for entry in archive {
+                if entry.path.hasPrefix(FileManager.macOSXDirectoryName + "/")
+                    || entry.path == FileManager.macOSXDirectoryName
+                    || entry.path == FileManager.macOSXDirectoryName + "/" { continue }
                 let directoryURL = destinationURL.appendingPathComponent(entry.path)
                 itemsExist = fileManager.itemExists(at: directoryURL)
                 if !itemsExist { break }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -254,7 +254,12 @@ extension ZIPFoundationTests {
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testFileModificationDate", testFileModificationDate),
             ("testFileModificationDateHelperMethods", testFileModificationDateHelperMethods),
-            ("testInvalidSymlinkCompressionMethodErrorConditions", testInvalidSymlinkCompressionMethodErrorConditions)
+            ("testInvalidSymlinkCompressionMethodErrorConditions", testInvalidSymlinkCompressionMethodErrorConditions),
+            ("testAppleDoubleCompanionPathDerivation", testAppleDoubleCompanionPathDerivation),
+            ("testRealEntryPathFromCompanion", testRealEntryPathFromCompanion),
+            ("testAppleDoubleEncodingRoundTrip", testAppleDoubleEncodingRoundTrip),
+            ("testAppleDoubleEncodingEmptyFinderInfoIgnored", testAppleDoubleEncodingEmptyFinderInfoIgnored),
+            ("testAppleDoubleDecodeRejectsBadMagic", testAppleDoubleDecodeRejectsBadMagic)
         ] + zip64Tests + darwinOnlyTests + swift5OnlyTests
     }
 
@@ -320,7 +325,19 @@ extension ZIPFoundationTests {
             // Applying permissions on symlinks is only relevant on Darwin platforms
             ("testSymlinkPermissionsTransferErrorConditions", testSymlinkPermissionsTransferErrorConditions),
             // Applying file modification dates is currently unsupported in corelibs Foundation
-            ("testSymlinkModificationDateTransferErrorConditions", testSymlinkModificationDateTransferErrorConditions)
+            ("testSymlinkModificationDateTransferErrorConditions", testSymlinkModificationDateTransferErrorConditions),
+            // AppleDouble xattr/resource-fork round-tripping is only wired up on Darwin.
+            ("testZipItemPreservesXattrsOnDarwin", testZipItemPreservesXattrsOnDarwin),
+            ("testZipItemPreservesResourceForkOnDarwin", testZipItemPreservesResourceForkOnDarwin),
+            ("testUnzipItemWithPreservesAppleMetadataFalse", testUnzipItemWithPreservesAppleMetadataFalse),
+            ("testArchiveAddEntryAddsCompanionOnDarwin", testArchiveAddEntryAddsCompanionOnDarwin),
+            ("testArchiveAddEntryRespectsPreservesAppleMetadataFalse",
+             testArchiveAddEntryRespectsPreservesAppleMetadataFalse),
+            ("testArchiveExtractAppliesCompanion", testArchiveExtractAppliesCompanion),
+            ("testArchiveExtractWithoutPreservesAppleMetadataSkipsCompanion",
+             testArchiveExtractWithoutPreservesAppleMetadataSkipsCompanion),
+            ("testArchiveExtractCompanionEntryItselfIsNotReinterpreted",
+             testArchiveExtractCompanionEntryItselfIsNotReinterpreted)
         ]
         #else
         return []

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		BA643D7C2648131C00018273 /* Archive+Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA643D7B2648131C00018273 /* Archive+Progress.swift */; };
 		BA85B4F2299160E4003F2748 /* Archive+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F1299160E4003F2748 /* Archive+Deprecated.swift */; };
 		BA85B4F42991614E003F2748 /* FileManager+ZIPDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */; };
+		BA85B4F52991614F003F2748 /* FileManager+AppleDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F62991614F003F2748 /* FileManager+AppleDouble.swift */; };
+		BA85B4F72991614F003F2748 /* ZIPFoundationAppleDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA85B4F82991614F003F2748 /* ZIPFoundationAppleDoubleTests.swift */; };
 		BA9AFCCA2ABB645F00A1268C /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA9AFCC82ABB643E00A1268C /* PrivacyInfo.xcprivacy */; };
 		BAAF13DA25CC140300070A95 /* ZIPFoundationErrorConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAF13D925CC140300070A95 /* ZIPFoundationErrorConditionTests.swift */; };
 		BACE20B826F7CE6C003BA312 /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */; };
@@ -99,6 +101,8 @@
 		BA643D7B2648131C00018273 /* Archive+Progress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Progress.swift"; sourceTree = "<group>"; };
 		BA85B4F1299160E4003F2748 /* Archive+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Deprecated.swift"; sourceTree = "<group>"; };
 		BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIPDeprecated.swift"; sourceTree = "<group>"; };
+		BA85B4F62991614F003F2748 /* FileManager+AppleDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+AppleDouble.swift"; sourceTree = "<group>"; };
+		BA85B4F82991614F003F2748 /* ZIPFoundationAppleDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZIPFoundationAppleDoubleTests.swift"; sourceTree = "<group>"; };
 		BA9AFCC82ABB643E00A1268C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BAAF13D925CC140300070A95 /* ZIPFoundationErrorConditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationErrorConditionTests.swift; sourceTree = "<group>"; };
 		BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+BackingConfiguration.swift"; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				OBJ_23 /* ZIPFoundationTests.swift */,
 				OBJ_24 /* ZIPFoundationWritingTests.swift */,
 				591C971226B0FF9F00F65F97 /* ZIPFoundationWritingTests+ZIP64.swift */,
+				BA85B4F82991614F003F2748 /* ZIPFoundationAppleDoubleTests.swift */,
 			);
 			name = ZIPFoundationTests;
 			path = Tests/ZIPFoundationTests;
@@ -235,6 +240,7 @@
 				BACE20BC26F7D545003BA312 /* Entry+Serialization.swift */,
 				590A7DA726B0F91E00CBEFB4 /* Entry+ZIP64.swift */,
 				82BD5DB32F1112D900DA5764 /* Entry+InfoZIP.swift */,
+				BA85B4F62991614F003F2748 /* FileManager+AppleDouble.swift */,
 				OBJ_15 /* FileManager+ZIP.swift */,
 				BA85B4F32991614E003F2748 /* FileManager+ZIPDeprecated.swift */,
 				BA643D79264811FB00018273 /* URL+ZIP.swift */,
@@ -356,6 +362,7 @@
 				59248AA226B6EC770078ABDA /* ZIPFoundationErrorConditionTests+ZIP64.swift in Sources */,
 				OBJ_38 /* ZIPFoundationTests.swift in Sources */,
 				OBJ_39 /* ZIPFoundationWritingTests.swift in Sources */,
+				BA85B4F72991614F003F2748 /* ZIPFoundationAppleDoubleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +383,7 @@
 				590A7DA826B0F91F00CBEFB4 /* Entry+ZIP64.swift in Sources */,
 				BACE20BA26F7D18A003BA312 /* Archive+Helpers.swift in Sources */,
 				BA85B4F42991614E003F2748 /* FileManager+ZIPDeprecated.swift in Sources */,
+				BA85B4F52991614F003F2748 /* FileManager+AppleDouble.swift in Sources */,
 				590A7DA626B0F8F800CBEFB4 /* Archive+ZIP64.swift in Sources */,
 				BA643D7A264811FB00018273 /* URL+ZIP.swift in Sources */,
 				BA58FB162951F49400892CE7 /* Date+ZIP.swift in Sources */,


### PR DESCRIPTION
Add support for preserving FinderInfo, resource forks, and extended attributes for files and directories across zip and unzip operations. This is done by adding dot-underscore-prefixed AppleDouble files to the archive during zip operations and, during unzip operations, applying the metadata in those files to the extracted files.

# Tests performed

- Full suite of unit tests included
- Tested for compatibility with Apple Archive Utility