### PR TITLE
Fix Xcode 27 deprecation warning

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,43 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let zlibPlatforms: [Platform] = [.linux, .android, .windows]
+let unixZlibPlatforms: [Platform] = [.linux, .android]
+
+let package = Package(
+    name: "ZIPFoundation",
+    products: [
+        .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])
+    ],
+    targets: [
+        .target(
+            name: "ZIPFoundation",
+            dependencies: [
+                .target(name: "CZLib", condition: .when(platforms: zlibPlatforms))
+            ],
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ],
+            cSettings: [
+                .define("_GNU_SOURCE", to: "1", .when(platforms: unixZlibPlatforms))
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ],
+            linkerSettings: [
+                .linkedLibrary("z", .when(platforms: unixZlibPlatforms)),
+                .linkedLibrary("zlib", .when(platforms: [.windows]))
+            ]),
+        .systemLibrary(
+            name: "CZLib",
+            pkgConfig: "zlib",
+            providers: [.brew(["zlib"]), .apt(["zlib"])]),
+        .testTarget(
+            name: "ZIPFoundationTests",
+            dependencies: ["ZIPFoundation"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
+        )
+    ],
+)

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -39,5 +39,5 @@ let package = Package(
                 .swiftLanguageMode(.v5)
             ]
         )
-    ],
+    ]
 )


### PR DESCRIPTION
## Fixes
When depending on ZIPFoundation in Xcode 27 beta, the compiler emits a warning:
```
SourcePackages/checkouts/ZIPFoundation/Package@swift-5.9.swift:23:61 'v4' is deprecated: watchOS 9.0 is the oldest supported version
```

# Changes proposed in this PR
We see that v4 is [indeed](https://github.com/swiftlang/swift-package-manager/blob/d3db8b9818272dd88ec2c4eaaab6ecc557e2ac8d/Sources/Runtimes/PackageDescription/SupportedPlatforms.swift#L695) **now** marked deprecated for swift-tools-version:5.7, but that was [not the case](https://github.com/swiftlang/swift-package-manager/blob/2dbd2ee3c87999a1d553d12dc065715b4111ac6b/Sources/PackageDescription/SupportedPlatforms.swift#L588) when Swift 5.9 was released, so a little bit of retconning happening here.

Since `supportedPlatforms` is actually used to *restrict minimum* SDK deployments, and all of Swift 6's [supported](https://developer.apple.com/xcode/system-requirements/) Apple platforms are supported by ZIPFoundation 😍, I propose to add a new Package.swift variant for Swift >= 6:
- without specifying supportedPlatforms, which will allow building on all Apple platforms
- keeping `swiftLanguageMode` at v5 until [Swift 6 support](https://github.com/weichsel/ZIPFoundation/pull/345) is ready.
