### PR TITLE
Fix deprecation warning in package manifest

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -7,7 +7,7 @@ let unixZlibPlatforms: [Platform] = [.linux, .android]
 let package = Package(
     name: "ZIPFoundation",
     platforms: [
-        .macOS(.v10_13), .iOS(.v12), .tvOS(.v12), .watchOS(.v4), .visionOS(.v1)
+        .macOS(.v10_13), .iOS(.v12), .tvOS(.v12), .watchOS(.v5), .visionOS(.v1)
     ],
     products: [
         .library(name: "ZIPFoundation", targets: ["ZIPFoundation"])


### PR DESCRIPTION
Fixes #387

# Changes proposed in this PR
* Raise the declared watchOS platform version in `Package@swift-5.9.swift` from `.v4` to `.v5`.

Xcode 27 annotates `WatchOSVersion.v4` as `deprecated: 5.7`, which is below the `swift-tools-version:5.9` declared by this manifest, so it warns. `.v5` through `.v8` are annotated `deprecated: 6.4` and cannot fire from a 5.9 manifest, so `.v5` is the smallest bump that clears the warning.

No `swift-tools-version` change is needed. No other platform needs changing: `macOS(.v10_13)`, `iOS(.v12)` and `tvOS(.v12)` are also annotated `deprecated: 6.4`.

`.v9` is the only watchOS value carrying no deprecation at all, so it would be durable if the manifest ever moves to tools version 6.4 or later. It raises the declared floor further than is needed today. Happy to switch to `.v9` if you prefer.

# Tests performed
* `swift build` and `swift test` pass on Xcode 27 and Xcode 26. 131 tests, 0 failures.
* `swift package --manifest-cache none dump-package` writes nothing to stderr on both.

# Further info for the reviewer
This is a smaller alternative to #384, not a competing duplicate. That PR adds a new `Package@swift-6.0.swift`, which changes which manifest Swift 6.0 and later toolchains select. This changes one token in the manifest that is already selected, and leaves manifest selection untouched. Same shape as #310.

# Open Issues
None.
