### PR TITLE
Fix infinite loop in Linux decode path when provider signals EOF early

### DIFF
--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -226,6 +226,15 @@ extension Data {
             stream.avail_in = UInt32(bufferSize)
             var chunk = try provider(position, bufferSize)
             position += Int64(chunk.count)
+            // The provider signalling EOF (empty chunk) before `inflate` reached
+            // `Z_STREAM_END` means the compressed stream is truncated or otherwise
+            // corrupted. Without this guard the outer loop skips the inner
+            // decompression block (which is where `result` is updated) and spins
+            // forever, since the loop exit condition `result != Z_STREAM_END`
+            // can never become false.
+            guard chunk.count > 0 else {
+                throw CompressionError.corruptedData
+            }
             try chunk.withUnsafeMutableBytes { (rawBufferPointer) in
                 if let baseAddress = rawBufferPointer.baseAddress, rawBufferPointer.count > 0 {
                     let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -157,6 +157,46 @@ extension ZIPFoundationTests {
                             throws: Data.CompressionError.corruptedData)
     }
 
+    /// Regression test for an infinite loop in the Linux `Data.decode` path
+    /// when the provider signals EOF (empty chunk) before `inflate` returns
+    /// `Z_STREAM_END`.
+    ///
+    /// The compressed data is a single deflate stored block header with
+    /// `BFINAL=0` and a 3-byte payload. After consuming that chunk `inflate`
+    /// has not seen a final block, so the outer loop asks the provider for
+    /// more input. The provider returns an empty `Data` to signal EOF.
+    ///
+    /// Prior to the fix, the empty chunk caused the inner decompression block
+    /// (which is the only place `result` is written) to be skipped by the
+    /// `rawBufferPointer.count > 0` guard. The outer `while result != Z_STREAM_END`
+    /// condition could therefore never become false, and the function looped
+    /// forever at 100% CPU with no observable output.
+    ///
+    /// After the fix, an empty provider chunk is treated as corruption and
+    /// throws `CompressionError.corruptedData` alongside the other malformed-
+    /// stream cases.
+    ///
+    /// The function is unconditional so that XCTest's Linux test discovery
+    /// picks it up via the `allTests` list, but the body is only compiled on
+    /// non-Apple platforms because `Data.decode` is only defined there.
+    func testDecodeThrowsWhenProviderSignalsEOFBeforeStreamEnd() {
+#if !os(macOS) && !os(iOS) && !os(tvOS) && !os(visionOS) && !os(watchOS)
+        let truncated = Data([0x00, 0x03, 0x00, 0xfc, 0xff, 0x41, 0x42, 0x43])
+        var providerCallCount = 0
+        let provider: Provider = { _, _ in
+            providerCallCount += 1
+            return providerCallCount == 1 ? truncated : Data()
+        }
+        XCTAssertSwiftError(
+            try Data.decode(bufferSize: 32 * 1024,
+                            skipCRC32: true,
+                            provider: provider,
+                            consumer: { _ in }),
+            throws: Data.CompressionError.corruptedData
+        )
+#endif
+    }
+
     func testCorruptSymbolicLinkErrorConditions() {
         let archive = self.archive(for: #function, mode: .read)
         for entry in archive {

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -193,6 +193,7 @@ extension ZIPFoundationTests {
             ("testArchiveUpdateErrorConditions", testArchiveUpdateErrorConditions),
             ("testCorruptFileErrorConditions", testCorruptFileErrorConditions),
             ("testCorruptSymbolicLinkErrorConditions", testCorruptSymbolicLinkErrorConditions),
+            ("testDecodeThrowsWhenProviderSignalsEOFBeforeStreamEnd", testDecodeThrowsWhenProviderSignalsEOFBeforeStreamEnd),
             ("testCreateArchiveAddCompressedEntry", testCreateArchiveAddCompressedEntry),
             ("testCRC32Calculation", testCRC32Calculation),
             ("testCreateArchiveAddDirectory", testCreateArchiveAddDirectory),


### PR DESCRIPTION
## What

When `Data.decode` on the Linux inflate path receives an empty `Data` from the provider before the deflate stream has emitted `Z_STREAM_END`, the outer `repeat ... while result != Z_STREAM_END` loop spins forever at 100% CPU.

The reason is the `rawBufferPointer.count > 0` guard around the inner decompression block: an empty chunk causes the entire block to be skipped, which means `result` is never updated (and the `Z_DATA_ERROR` / `Z_NEED_DICT` / `Z_MEM_ERROR` guard inside it never fires). The outer condition can therefore never become false, and because the body only spins on syscall-free work, the task cannot be cancelled from Swift Concurrency either.

The fix adds a `guard chunk.count > 0 else { throw .corruptedData }` right after the provider returns. It cannot fire on a well-formed stream because a valid deflate stream signals `Z_STREAM_END` on the same iteration that consumes its final compressed byte, and the outer loop exits before asking the provider again. Any case where the provider is asked once more and returns empty is by definition truncated or corrupted input, which is exactly the treatment the code already applies to other malformed-stream conditions.

The Apple path (`Data.process`) is not affected: `compression_stream_process` is called with `COMPRESSION_STREAM_FINALIZE` when the source buffer is short, so a short read is an explicit signal to the codec that no more input is coming, and it either finishes cleanly or reports an error that breaks the loop.

## Why this matters

Ran into this in production on Linux CI runners. Any archive whose deflate stream ends without a proper final-block marker, or whose central-directory `compressed_size` is even slightly off, hangs `unzipItem` with no output until the job's wall-clock timeout fires (multi-hour cancellations). The bug is silent because the loop is pure CPU work with no logging, and it's Linux-only because Apple platforms take a different code path.

I reduced the trigger to an 8-byte truncated deflate payload driven directly at `Data.decode`, which is the shape of the added regression test. Before the patch the test hangs forever. After the patch it throws `CompressionError.corruptedData` and passes in about a millisecond.

## Test

Added `testDecodeThrowsWhenProviderSignalsEOFBeforeStreamEnd` in `ZIPFoundationReadingTests.swift`. The function is declared unconditionally so that Linux XCTest's `allTests` discovery picks it up, but its body is gated to non-Apple platforms because `Data.decode` is only defined there.

```
Test Case 'ZIPFoundationTests.testDecodeThrowsWhenProviderSignalsEOFBeforeStreamEnd' passed (0.001 seconds)
```

## Consideration for reviewers

If you'd prefer, I'm happy to also propagate the `size` argument that `Data.decompress(size:...)` already has into `Data.decode` and bound the number of provider bytes to that size, which would give the Linux path the same "know when you've read enough" guarantee that the Apple path effectively gets for free. Happy to do that in a follow-up if you'd like to keep this PR minimal, or to fold it into this one. Let me know your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)